### PR TITLE
feat(pwa): service worker + update prompt; CF invalidation helper; deploy cache headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "deploy:all": "./scripts/deploy-multi.sh all",
     "deploy:s3": "aws s3 sync ./out s3://todos.vinny.dev --delete --cache-control 'max-age=31536000,public' --exclude '*.html' && aws s3 sync ./out s3://todos.vinny.dev --delete --cache-control 'max-age=0,no-cache,no-store,must-revalidate' --include '*.html'",
     "deploy:invalidate": "aws cloudfront create-invalidation --distribution-id E2UEF9C8JAMJH5 --paths '/*'",
+    "deploy:invalidate:cascade": "aws cloudfront create-invalidation --distribution-id E1351EA4HZ20NY --paths '/*'",
+    "invalidate": "./scripts/invalidate.sh",
+    "invalidate:cascade": "./scripts/invalidate.sh cascade",
+    "invalidate:todos": "./scripts/invalidate.sh todos",
     "deploy:check": "curl -I https://todos.vinny.dev",
     "deploy:check:cascade": "curl -I https://cascade.vinny.dev"
   },

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,93 @@
+// Minimal service worker for Cascade PWA
+// Strategy:
+// - Navigation requests: network-first, fallback to cache
+// - Static assets: cache-first with background update
+// - Supports immediate activation via postMessage { type: 'SKIP_WAITING' }
+
+const CACHE_VERSION = 'v1-2025-08-31';
+const ASSET_CACHE = `assets-${CACHE_VERSION}`;
+const PAGE_CACHE = `pages-${CACHE_VERSION}`;
+
+self.addEventListener('install', (event) => {
+  // Activate the new SW as soon as it's finished installing
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  // Clean up old caches and take control immediately
+  event.waitUntil(
+    (async () => {
+      try {
+        const keys = await caches.keys();
+        await Promise.all(
+          keys
+            .filter((k) => k !== ASSET_CACHE && k !== PAGE_CACHE)
+            .map((k) => caches.delete(k))
+        );
+      } finally {
+        await self.clients.claim();
+      }
+    })()
+  );
+});
+
+self.addEventListener('message', (event) => {
+  if (event?.data?.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
+
+self.addEventListener('fetch', (event) => {
+  const req = event.request;
+  const url = new URL(req.url);
+
+  // Only handle same-origin requests
+  if (url.origin !== self.location.origin) return;
+
+  // Network-first for navigations (HTML)
+  if (req.mode === 'navigate') {
+    event.respondWith(
+      (async () => {
+        try {
+          const res = await fetch(req);
+          const cache = await caches.open(PAGE_CACHE);
+          cache.put(req, res.clone()).catch(() => {});
+          return res;
+        } catch {
+          const cached = await caches.match(req);
+          if (cached) return cached;
+          // Fallback to root index if available
+          const fallback = await caches.match('/index.html');
+          return fallback || Response.error();
+        }
+      })()
+    );
+    return;
+  }
+
+  // Cache-first for versioned/static assets
+  const isStaticAsset =
+    url.pathname.startsWith('/_next/') ||
+    url.pathname.startsWith('/images/') ||
+    /\.(?:js|css|svg|png|jpg|jpeg|gif|webp|ico|woff2?)$/i.test(url.pathname);
+
+  if (isStaticAsset) {
+    event.respondWith(
+      (async () => {
+        const cache = await caches.open(ASSET_CACHE);
+        const cached = await cache.match(req);
+        const networkPromise = fetch(req)
+          .then((res) => {
+            if (res && res.status === 200) {
+              cache.put(req, res.clone()).catch(() => {});
+            }
+            return res;
+          })
+          .catch(() => undefined);
+
+        return cached || (await networkPromise) || Response.error();
+      })()
+    );
+  }
+});
+

--- a/scripts/deploy-multi.sh
+++ b/scripts/deploy-multi.sh
@@ -134,7 +134,9 @@ deploy_to_s3() {
         --cache-control "max-age=31536000,public" \
         --exclude "*.html" \
         --exclude "*.json" \
-        --exclude "*.txt"
+        --exclude "*.txt" \
+        --exclude "sw.js" \
+        --exclude "manifest.json"
     
     # Sync HTML files with no cache
     info "Uploading HTML files..."
@@ -150,6 +152,21 @@ deploy_to_s3() {
         --cache-control "max-age=300,public" \
         --include "*.json" \
         --include "*.txt"
+
+    # Ensure service worker and manifest are never cached
+    if [ -f "out/sw.js" ]; then
+        info "Uploading service worker with no-cache..."
+        aws s3 cp ./out/sw.js $S3_BUCKET/sw.js \
+            --cache-control "max-age=0,no-cache,no-store,must-revalidate" \
+            --content-type "application/javascript"
+    fi
+
+    if [ -f "out/manifest.json" ]; then
+        info "Uploading manifest with short/no-cache..."
+        aws s3 cp ./out/manifest.json $S3_BUCKET/manifest.json \
+            --cache-control "max-age=0,no-cache,must-revalidate" \
+            --content-type "application/manifest+json"
+    fi
     
     info "✓ S3 deployment completed"
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -89,7 +89,9 @@ deploy_to_s3() {
         --cache-control "max-age=31536000,public" \
         --exclude "*.html" \
         --exclude "*.json" \
-        --exclude "*.txt"
+        --exclude "*.txt" \
+        --exclude "sw.js" \
+        --exclude "manifest.json"
     
     # Sync HTML files with no cache
     info "Uploading HTML files..."
@@ -105,6 +107,21 @@ deploy_to_s3() {
         --cache-control "max-age=300,public" \
         --include "*.json" \
         --include "*.txt"
+
+    # Ensure service worker and manifest are never cached
+    if [ -f "out/sw.js" ]; then
+        info "Uploading service worker with no-cache..."
+        aws s3 cp ./out/sw.js $S3_BUCKET/sw.js \
+            --cache-control "max-age=0,no-cache,no-store,must-revalidate" \
+            --content-type "application/javascript"
+    fi
+
+    if [ -f "out/manifest.json" ]; then
+        info "Uploading manifest with short/no-cache..."
+        aws s3 cp ./out/manifest.json $S3_BUCKET/manifest.json \
+            --cache-control "max-age=0,no-cache,must-revalidate" \
+            --content-type "application/manifest+json"
+    fi
     
     info "✓ S3 deployment completed"
 }

--- a/scripts/invalidate.sh
+++ b/scripts/invalidate.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# CloudFront invalidation helper using deploy-config.json
+# Usage:
+#   ./scripts/invalidate.sh <environment|all> [--paths "/*"] [--wait]
+# Examples:
+#   ./scripts/invalidate.sh cascade
+#   ./scripts/invalidate.sh todos --paths "/sw.js /index.html" --wait
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+CONFIG_FILE="$PROJECT_DIR/deploy-config.json"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[INVALIDATE]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+err()  { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
+
+if ! command -v aws >/dev/null 2>&1; then
+  err "AWS CLI not found. Install and configure credentials first."
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  err "jq not found. Install jq to parse JSON config."
+fi
+
+ENV_ARG="${1:-}"
+shift || true
+
+if [ -z "$ENV_ARG" ]; then
+  ENV_ARG=$(jq -r '.default_environment' "$CONFIG_FILE")
+  warn "No environment supplied; using default: $ENV_ARG"
+fi
+
+PATHS="/*"
+WAIT=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --paths)
+      PATHS="$2"; shift 2;;
+    --wait)
+      WAIT=true; shift;;
+    *)
+      warn "Unknown option: $1"; shift;;
+  esac
+done
+
+invalidate_one() {
+  local env_key="$1"
+  local dist_id domain
+
+  dist_id=$(jq -r ".environments.$env_key.cloudfront_distribution_id" "$CONFIG_FILE")
+  domain=$(jq -r ".environments.$env_key.domain" "$CONFIG_FILE")
+
+  if [ "$dist_id" = "null" ] || [ -z "$dist_id" ]; then
+    err "No CloudFront distribution id for environment: $env_key"
+  fi
+
+  log "Creating invalidation for $env_key ($domain) on $dist_id with paths: $PATHS"
+  INVALIDATION_ID=$(aws cloudfront create-invalidation \
+    --distribution-id "$dist_id" \
+    --paths $PATHS \
+    --query 'Invalidation.Id' \
+    --output text)
+
+  log "Created invalidation: $INVALIDATION_ID"
+
+  if [ "$WAIT" = true ]; then
+    log "Waiting for invalidation to complete..."
+    aws cloudfront wait invalidation-completed --distribution-id "$dist_id" --id "$INVALIDATION_ID"
+    log "Invalidation completed."
+  else
+    warn "Invalidation in progress; propagation typically takes 5-15 minutes."
+  fi
+}
+
+if [ "$ENV_ARG" = "all" ]; then
+  for env in $(jq -r '.environments | keys[]' "$CONFIG_FILE"); do
+    invalidate_one "$env"
+  done
+else
+  invalidate_one "$ENV_ARG"
+fi
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "@/components/ThemeProvider";
+import PwaUpdater from "@/components/PwaUpdater";
 
 const geist = Geist({ 
   subsets: ["latin"],
@@ -85,6 +86,7 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           {children}
+          <PwaUpdater />
           <Toaster />
         </ThemeProvider>
       </body>

--- a/src/components/PwaUpdater.tsx
+++ b/src/components/PwaUpdater.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+export default function PwaUpdater() {
+  const [waiting, setWaiting] = useState<ServiceWorker | null>(null);
+  const [show, setShow] = useState(false);
+
+  // Only attempt to register in supported browsers
+  const canUseSW = useMemo(
+    () => typeof window !== "undefined" && "serviceWorker" in navigator && process.env.NODE_ENV === "production",
+    []
+  );
+
+  useEffect(() => {
+    if (!canUseSW) return;
+    let mounted = true;
+
+    // Register the service worker
+    navigator.serviceWorker
+      .register("/sw.js")
+      .then((registration) => {
+        if (!mounted) return;
+
+        const onUpdateFound = () => {
+          const installing = registration.installing;
+          if (!installing) return;
+          installing.addEventListener("statechange", () => {
+            if (installing.state === "installed") {
+              // controller exists => this is an update
+              if (navigator.serviceWorker.controller) {
+                setWaiting(registration.waiting);
+                setShow(true);
+              }
+            }
+          });
+        };
+
+        registration.addEventListener("updatefound", onUpdateFound);
+
+        // If there's already a waiting worker (e.g., returned to app)
+        if (registration.waiting) {
+          setWaiting(registration.waiting);
+          setShow(true);
+        }
+
+        // Check for updates whenever the app becomes visible
+        const onVisibility = () => {
+          if (document.visibilityState === "visible") {
+            registration.update().catch(() => {});
+          }
+        };
+        document.addEventListener("visibilitychange", onVisibility);
+
+        // Cleanup
+        return () => {
+          registration.removeEventListener("updatefound", onUpdateFound);
+          document.removeEventListener("visibilitychange", onVisibility);
+        };
+      })
+      .catch(() => {});
+
+    // Reload the page when the new SW takes control
+    const onControllerChange = () => {
+      window.location.reload();
+    };
+    navigator.serviceWorker.addEventListener("controllerchange", onControllerChange);
+
+    return () => {
+      mounted = false;
+      navigator.serviceWorker.removeEventListener("controllerchange", onControllerChange);
+    };
+  }, [canUseSW]);
+
+  const reload = () => {
+    try {
+      waiting?.postMessage({ type: "SKIP_WAITING" });
+    } catch {}
+  };
+
+  if (!show) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed inset-x-3 bottom-3 z-50 rounded-md border bg-background/95 p-3 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/60"
+      style={{ paddingBottom: "calc(env(safe-area-inset-bottom) + 0.5rem)" }}
+    >
+      <div className="flex items-center justify-between gap-3 text-sm">
+        <span>Update available. Reload to apply.</span>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setShow(false)}
+            className="rounded px-2 py-1 text-xs text-muted-foreground hover:bg-muted"
+          >
+            Later
+          </button>
+          <button
+            type="button"
+            onClick={reload}
+            className="rounded bg-primary px-2 py-1 text-xs font-medium text-primary-foreground hover:opacity-90"
+          >
+            Reload
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR adds a minimal PWA service worker and an in-app "Update available — Reload" prompt, plus CloudFront invalidation tooling and safer deploy caching.\n\nChanges:\n- public/sw.js: network-first for navigations, cache-first for versioned/static assets; supports SKIP_WAITING + clients.claim\n- src/components/PwaUpdater.tsx: registers SW, detects updates, prompts to reload, triggers swap and auto-reload on controllerchange\n- src/app/layout.tsx: wires <PwaUpdater />\n- scripts/invalidate.sh: helper to invalidate CloudFront by environment using deploy-config.json (supports --paths and --wait)\n- package.json: adds npm scripts: invalidate, invalidate:cascade, invalidate:todos, deploy:invalidate:cascade\n- scripts/deploy.sh & scripts/deploy-multi.sh: exclude sw.js/manifest.json from long-cache sync; upload sw.js with no-store and manifest with no-cache\n\nWhy:\n- Fixes stale PWA behavior on iOS by ensuring HTML and SW are refreshed and by prompting users to reload when updates are available.\n\nDeploy notes:\n- After deploy, run invalidation: npm run invalidate:cascade (or limit to "/sw.js /index.html" paths).\n- Ensure S3/CloudFront headers remain as configured in scripts for SW and HTML.\n