### PR TITLE
feat: start sidebar collapsed on mobile devices

### DIFF
--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -12,6 +12,7 @@ import { useTaskStore } from "@/lib/stores/taskStore";
 import { useBoardStore } from "@/lib/stores/boardStore";
 import { useSettingsStore } from "@/lib/stores/settingsStore";
 import { notificationManager } from "@/lib/utils/notifications";
+import { detectTouchCapabilities } from "@/lib/utils/iosDetection";
 
 // Lazy load keyboard components
 const GlobalHotkeys = dynamic(() => import("./GlobalHotkeys").then(mod => ({ default: mod.GlobalHotkeys })), {
@@ -22,7 +23,17 @@ const KeyboardShortcutsDialog = dynamic(() => import("./KeyboardShortcutsDialog"
 });
 
 export function KanbanBoard() {
-  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+  // Determine initial sidebar state based on device type
+  const getInitialSidebarState = () => {
+    // Only run on client side to avoid hydration mismatches
+    if (typeof window === 'undefined') return true;
+    
+    const touchCapabilities = detectTouchCapabilities();
+    // Start collapsed on mobile devices (phones), but open on tablets and desktop
+    return !touchCapabilities.isLikelyMobile;
+  };
+  
+  const [isSidebarOpen, setIsSidebarOpen] = useState(getInitialSidebarState);
   const [, setIsInitialized] = useState(false);
   const [showKeyboardShortcuts, setShowKeyboardShortcuts] = useState(false);
   const { initializeStore, setBoardFilter, tasks } = useTaskStore();


### PR DESCRIPTION
Implements mobile-first sidebar behavior where the sidebar starts collapsed on mobile devices but remains open on tablets and desktop.

## Changes
- Import detectTouchCapabilities from iOS detection utilities
- Add getInitialSidebarState() for device-based initialization
- Start sidebar collapsed on mobile (isLikelyMobile: true)
- Keep sidebar open on tablets and desktop
- Handle SSR safely to prevent hydration mismatches
- Maintain existing hamburger menu toggle functionality

Fixes #18

Generated with [Claude Code](https://claude.ai/code)