### PR TITLE
fix: add explicit undefined to useRef initialization

### DIFF
--- a/src/components/CrossBoardNavigationHandler.tsx
+++ b/src/components/CrossBoardNavigationHandler.tsx
@@ -14,7 +14,7 @@ export function CrossBoardNavigationHandler({ children }: CrossBoardNavigationHa
   const { setCurrentBoard, boards } = useBoardStore();
 
   // Use ref to enable retry without circular dependency
-  const handleNavigationRef = useRef<(taskId: string) => Promise<boolean>>();
+  const handleNavigationRef = useRef<(taskId: string) => Promise<boolean>>(undefined);
 
   // Handle cross-board navigation with error handling and focus management
   const handleCrossBoardNavigation = useCallback(async (taskId: string) => {


### PR DESCRIPTION
## Summary
- Add explicit `undefined` argument to `useRef` call in `CrossBoardNavigationHandler.tsx`
- TypeScript requires this when the ref type doesn't include `undefined`

This was discovered during the v3.6.1 deployment build.

## Test plan
- [x] Build passes (`bun run build`)
- [x] Successfully deployed to production

🤖 Generated with [Claude Code](https://claude.ai/code)