### PR TITLE
fix: add XSSProtection to CloudFront response headers policy update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # testing
 /coverage
+test-results
 
 # next.js
 /.next/

--- a/scripts/update-security-headers.sh
+++ b/scripts/update-security-headers.sh
@@ -108,6 +108,12 @@ for POLICY_ID in $POLICY_IDS; do
       "IncludeSubdomains": true,
       "Preload": false
     }
+    # Set X-XSS-Protection (deprecated but required by CloudFront API)
+    | .SecurityHeadersConfig.XSSProtection = {
+      "Override": true,
+      "Protection": true,
+      "ModeBlock": true
+    }
     '
   )"
 


### PR DESCRIPTION
## Summary
- Adds missing `XSSProtection` block to the jq filter in `update-security-headers.sh`, fixing a `ParamValidation` error from the CloudFront API
- Sets `X-XSS-Protection: 1; mode=block` (legacy header, but required by CloudFront when already present in the policy)
- Adds `test-results` to `.gitignore`

## Test plan
- [ ] Run `./scripts/update-security-headers.sh --dry-run` and verify the output includes `XSSProtection` in the policy config
- [ ] Run against actual CloudFront policy and confirm no `ParamValidation` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)