### PR TITLE
fix(about): harden localStorage access and improve UX for about page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban-todos-temp",
-  "version": "4.0.0",
+  "version": "4.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/about/EnterAppLink.tsx
+++ b/src/components/about/EnterAppLink.tsx
@@ -11,7 +11,11 @@ interface EnterAppLinkProps {
 
 export function EnterAppLink({ children, className }: EnterAppLinkProps) {
   const markVisited = useCallback(() => {
-    localStorage.setItem(VISITED_KEY, "true");
+    try {
+      localStorage.setItem(VISITED_KEY, "true");
+    } catch {
+      // localStorage unavailable — non-critical, skip silently
+    }
   }, []);
 
   return (

--- a/src/components/about/FirstVisitRedirect.tsx
+++ b/src/components/about/FirstVisitRedirect.tsx
@@ -6,7 +6,13 @@ import { VISITED_KEY } from "./visitedKey";
 
 function hasVisitedBefore(): boolean {
   if (typeof window === "undefined") return true;
-  return localStorage.getItem(VISITED_KEY) !== null;
+  try {
+    return localStorage.getItem(VISITED_KEY) !== null;
+  } catch {
+    // localStorage unavailable (private browsing, disabled storage)
+    // Default to "visited" so the user sees the main app
+    return true;
+  }
 }
 
 /**

--- a/src/components/about/HeroSection.tsx
+++ b/src/components/about/HeroSection.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Lock, Monitor, Code2, ArrowRight } from "@/lib/icons";
 import { EnterAppLink } from "./EnterAppLink";
+import { SmoothScrollLink } from "./SmoothScrollLink";
 
 export function HeroSection() {
   return (
@@ -29,7 +30,9 @@ export function HeroSection() {
             </EnterAppLink>
           </Button>
           <Button variant="ghost" size="lg" asChild>
-            <a href="#how-it-works">See how it works</a>
+            <SmoothScrollLink href="#how-it-works">
+              See how it works
+            </SmoothScrollLink>
           </Button>
         </div>
 

--- a/src/components/about/ScrollReveal.tsx
+++ b/src/components/about/ScrollReveal.tsx
@@ -25,7 +25,7 @@ export function ScrollReveal({ children, className }: ScrollRevealProps) {
           observer.unobserve(element);
         }
       },
-      { threshold: REVEAL_THRESHOLD }
+      { threshold: REVEAL_THRESHOLD, rootMargin: "0px 0px -60px 0px" }
     );
 
     observer.observe(element);

--- a/src/components/about/SmoothScrollLink.tsx
+++ b/src/components/about/SmoothScrollLink.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+interface SmoothScrollLinkProps {
+  href: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function SmoothScrollLink({
+  href,
+  children,
+  className,
+}: SmoothScrollLinkProps) {
+  const targetId = href.replace("#", "");
+
+  return (
+    <a
+      href={href}
+      className={className}
+      onClick={(e) => {
+        e.preventDefault();
+        document.getElementById(targetId)?.scrollIntoView({ behavior: "smooth" });
+      }}
+    >
+      {children}
+    </a>
+  );
+}

--- a/src/components/about/__tests__/EnterAppLink.test.tsx
+++ b/src/components/about/__tests__/EnterAppLink.test.tsx
@@ -1,0 +1,55 @@
+import { render, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { VISITED_KEY } from "../visitedKey";
+
+// Mock next/link to render a plain anchor
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    onClick,
+    ...props
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    href: string;
+    className?: string;
+  }) => (
+    <a {...props} onClick={onClick}>
+      {children}
+    </a>
+  ),
+}));
+
+import { EnterAppLink } from "../EnterAppLink";
+
+describe("EnterAppLink", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sets visited key in localStorage on click", () => {
+    const { getByText } = render(
+      <EnterAppLink>Open App</EnterAppLink>
+    );
+
+    fireEvent.click(getByText("Open App"));
+    expect(localStorage.getItem(VISITED_KEY)).toBe("true");
+  });
+
+  it("does not throw when localStorage is unavailable", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+
+    const { getByText } = render(
+      <EnterAppLink>Open App</EnterAppLink>
+    );
+
+    expect(() => fireEvent.click(getByText("Open App"))).not.toThrow();
+  });
+});

--- a/src/components/about/__tests__/FirstVisitRedirect.test.tsx
+++ b/src/components/about/__tests__/FirstVisitRedirect.test.tsx
@@ -1,0 +1,71 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { VISITED_KEY } from "../visitedKey";
+
+// Mock next/navigation
+const mockReplace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+// Must import after mocks are set up
+import { FirstVisitGate } from "../FirstVisitRedirect";
+
+describe("FirstVisitGate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders children when user has visited before", () => {
+    localStorage.setItem(VISITED_KEY, "true");
+
+    const { getByText } = render(
+      <FirstVisitGate>
+        <p>App Content</p>
+      </FirstVisitGate>
+    );
+
+    expect(getByText("App Content")).toBeDefined();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /about/ when user has not visited", () => {
+    render(
+      <FirstVisitGate>
+        <p>App Content</p>
+      </FirstVisitGate>
+    );
+
+    expect(mockReplace).toHaveBeenCalledWith("/about/");
+  });
+
+  it("does not render children for first-time visitors", () => {
+    const { queryByText } = render(
+      <FirstVisitGate>
+        <p>App Content</p>
+      </FirstVisitGate>
+    );
+
+    expect(queryByText("App Content")).toBeNull();
+  });
+
+  it("defaults to visited when localStorage throws", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+
+    const { getByText } = render(
+      <FirstVisitGate>
+        <p>App Content</p>
+      </FirstVisitGate>
+    );
+
+    expect(getByText("App Content")).toBeDefined();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Add try-catch protection around `localStorage` access in `FirstVisitRedirect` and `EnterAppLink` to prevent crashes in private browsing or restricted storage environments
- Add smooth scroll behavior for "See how it works" anchor navigation via new `SmoothScrollLink` client component
- Add `rootMargin` to `ScrollReveal` IntersectionObserver for smoother animation triggers before elements enter viewport
- Add test coverage for first-visit redirect logic and localStorage error paths (6 new tests)
- Bump version to 4.4.0

## Test plan
- [x] All 6 new tests pass (`bun run test -- --run src/components/about/`)
- [x] Production build succeeds (`bun run build`)
- [x] Lint passes with no new warnings
- [ ] Verify smooth scroll works on `/about` page in browser
- [ ] Verify first-visit redirect still works in normal and private browsing