### PR TITLE
feat: task completion confetti + sample export refresh + audit cleanup

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,41 +20,43 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
+        "canvas-confetti": "^1.9.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "fast-deep-equal": "^3.1.3",
         "lucide-react": "^0.577.0",
-        "next": "^16.2.2",
+        "next": "^16.2.3",
         "next-themes": "^0.4.6",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "zustand": "^5.0.12",
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
-        "@next/bundle-analyzer": "^16.2.2",
+        "@next/bundle-analyzer": "^16.2.3",
         "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4.2.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@types/canvas-confetti": "^1.9.0",
         "@types/node": "^25.5.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.2.0",
-        "baseline-browser-mapping": "^2.10.14",
+        "baseline-browser-mapping": "^2.10.16",
         "eslint": "^9.39.4",
-        "eslint-config-next": "^16.2.2",
+        "eslint-config-next": "^16.2.3",
         "eslint-plugin-react": "^7.37.5",
         "fake-indexeddb": "^6.2.5",
-        "jsdom": "^29.0.1",
+        "jsdom": "^29.0.2",
         "rimraf": "^6.1.3",
         "tailwindcss": "^4.2.2",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5.9.3",
-        "vitest": "^4.1.2",
+        "vitest": "^4.1.3",
       },
     },
   },
@@ -62,19 +64,23 @@
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@typescript-eslint/typescript-estree/minimatch": "9.0.9",
+    "brace-expansion": "^2.0.2",
     "eslint-plugin-import/minimatch": "3.1.5",
     "eslint-plugin-jsx-a11y/minimatch": "3.1.5",
     "eslint-plugin-react/minimatch": "3.1.5",
+    "flatted": "^3.4.2",
+    "picomatch": "^4.0.4",
     "rollup": "4.59.0",
+    "vite": "^7.3.2",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
-    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.0.1", "", { "dependencies": { "@csstools/css-calc": "^3.1.1", "@csstools/css-color-parser": "^4.0.2", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0", "lru-cache": "^11.2.6" } }, "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw=="],
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.8", "", { "dependencies": { "@csstools/css-calc": "^3.1.1", "@csstools/css-color-parser": "^4.0.2", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-OISPR9c2uPo23rUdvfEQiLPjoMLOpEeLNnP5iGkxr6tDDxJd3NjD+6fxY0mdaMbIPUjFGL4HFOJqLvow5q4aqQ=="],
 
-    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.0.4", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7" } }, "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w=="],
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.0.8", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-erMO6FgtM02dC24NGm0xufMzWz5OF0wXKR7BpvGD973bq/GbmR8/DbxNZbj0YevQ5hlToJaWSVK/G9/NDgGEVw=="],
 
     "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
 
@@ -300,27 +306,27 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
-    "@next/bundle-analyzer": ["@next/bundle-analyzer@16.2.2", "", { "dependencies": { "webpack-bundle-analyzer": "4.10.1" } }, "sha512-wIpZBHyCv1y+y0dnFmqQFlpX91V94Z7RKnpu1TRP0BRaWB/1M74Iqxa9IJ8lzSO0FyTqKldgDHoQJJmn8F+gIA=="],
+    "@next/bundle-analyzer": ["@next/bundle-analyzer@16.2.3", "", { "dependencies": { "webpack-bundle-analyzer": "4.10.1" } }, "sha512-aDwW4f4SVqbQDWzSBHQJ1KI6H+lx8oX/vS3xGqzLajUu+KQb7uakK88AIMvRIf7TlIonce67g594rzpxvBuJIw=="],
 
-    "@next/env": ["@next/env@16.2.2", "", {}, "sha512-LqSGz5+xGk9EL/iBDr2yo/CgNQV6cFsNhRR2xhSXYh7B/hb4nePCxlmDvGEKG30NMHDFf0raqSyOZiQrO7BkHQ=="],
+    "@next/env": ["@next/env@16.2.3", "", {}, "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA=="],
 
-    "@next/eslint-plugin-next": ["@next/eslint-plugin-next@16.2.2", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-IOPbWzDQ+76AtjZioaCjpIY72xNSDMnarZ2GMQ4wjNLvnJEJHqxQwGFhgnIWLV9klb4g/+amg88Tk5OXVpyLTw=="],
+    "@next/eslint-plugin-next": ["@next/eslint-plugin-next@16.2.3", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-nE/b9mht28XJxjTwKs/yk7w4XTaU3t40UHVAky6cjiijdP/SEy3hGsnQMPxmXPTpC7W4/97okm6fngKnvCqVaA=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-B92G3ulrwmkDSEJEp9+XzGLex5wC1knrmCSIylyVeiAtCIfvEJYiN3v5kXPlYt5R4RFlsfO/v++aKV63Acrugg=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-7ZwSgNKJNQiwW0CKhNm9B1WS2L1Olc4B2XY0hPYCAL3epFnugMhuw5TMWzMilQ3QCZcCHoYm9NGWTHbr5REFxw=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-c3m8kBHMziMgo2fICOP/cd/5YlrxDU5YYjAJeQLyFsCqVF8xjOTH/QYG4a2u48CvvZZSj1eHQfBCbyh7kBr30Q=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-aHaKceJgdySReT7qeck5oShucxWRiiEuwCGK8HHALe6yZga8uyFpLkPgaRw3kkF04U7ROogL/suYCNt/+CuXGA=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.3", "", { "os": "win32", "cpu": "x64" }, "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -518,6 +524,8 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/canvas-confetti": ["@types/canvas-confetti@1.9.0", "", {}, "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -594,19 +602,19 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
 
-    "@vitest/expect": ["@vitest/expect@4.1.2", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.2", "@vitest/utils": "4.1.2", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ=="],
+    "@vitest/expect": ["@vitest/expect@4.1.3", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.3", "@vitest/utils": "4.1.3", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.1.2", "", { "dependencies": { "@vitest/spy": "4.1.2", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q=="],
+    "@vitest/mocker": ["@vitest/mocker@4.1.3", "", { "dependencies": { "@vitest/spy": "4.1.3", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.2", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.3", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg=="],
 
-    "@vitest/runner": ["@vitest/runner@4.1.2", "", { "dependencies": { "@vitest/utils": "4.1.2", "pathe": "^2.0.3" } }, "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ=="],
+    "@vitest/runner": ["@vitest/runner@4.1.3", "", { "dependencies": { "@vitest/utils": "4.1.3", "pathe": "^2.0.3" } }, "sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.1.2", "", { "dependencies": { "@vitest/pretty-format": "4.1.2", "@vitest/utils": "4.1.2", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A=="],
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.3", "", { "dependencies": { "@vitest/pretty-format": "4.1.3", "@vitest/utils": "4.1.3", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ=="],
 
-    "@vitest/spy": ["@vitest/spy@4.1.2", "", {}, "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA=="],
+    "@vitest/spy": ["@vitest/spy@4.1.3", "", {}, "sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw=="],
 
-    "@vitest/utils": ["@vitest/utils@4.1.2", "", { "dependencies": { "@vitest/pretty-format": "4.1.2", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ=="],
+    "@vitest/utils": ["@vitest/utils@4.1.3", "", { "dependencies": { "@vitest/pretty-format": "4.1.3", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -656,11 +664,11 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.14", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-fOVLPAsFTsQfuCkvahZkzq6nf8KvGWanlYoTh0SVA0A/PIUxQGU2AOZAoD95n2gFLVDW/jP6sbGLny95nmEuHA=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.16", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA=="],
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
-    "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+    "brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -675,6 +683,8 @@
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001777", "", {}, "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ=="],
+
+    "canvas-confetti": ["canvas-confetti@1.9.4", "", {}, "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
@@ -691,8 +701,6 @@
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
-
-    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
@@ -776,7 +784,7 @@
 
     "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
 
-    "eslint-config-next": ["eslint-config-next@16.2.2", "", { "dependencies": { "@next/eslint-plugin-next": "16.2.2", "eslint-import-resolver-node": "^0.3.6", "eslint-import-resolver-typescript": "^3.5.2", "eslint-plugin-import": "^2.32.0", "eslint-plugin-jsx-a11y": "^6.10.0", "eslint-plugin-react": "^7.37.0", "eslint-plugin-react-hooks": "^7.0.0", "globals": "16.4.0", "typescript-eslint": "^8.46.0" }, "peerDependencies": { "eslint": ">=9.0.0", "typescript": ">=3.3.1" }, "optionalPeers": ["typescript"] }, "sha512-6VlvEhwoug2JpVgjZDhyXrJXUEuPY++TddzIpTaIRvlvlXXFgvQUtm3+Zr84IjFm0lXtJt73w19JA08tOaZVwg=="],
+    "eslint-config-next": ["eslint-config-next@16.2.3", "", { "dependencies": { "@next/eslint-plugin-next": "16.2.3", "eslint-import-resolver-node": "^0.3.6", "eslint-import-resolver-typescript": "^3.5.2", "eslint-plugin-import": "^2.32.0", "eslint-plugin-jsx-a11y": "^6.10.0", "eslint-plugin-react": "^7.37.0", "eslint-plugin-react-hooks": "^7.0.0", "globals": "16.4.0", "typescript-eslint": "^8.46.0" }, "peerDependencies": { "eslint": ">=9.0.0", "typescript": ">=3.3.1" }, "optionalPeers": ["typescript"] }, "sha512-Dnkrylzjof/Az7iNoIQJqD18zTxQZcngir19KJaiRsMnnjpQSVoa6aEg/1Q4hQC+cW90uTlgQYadwL1CYNwFWA=="],
 
     "eslint-import-resolver-node": ["eslint-import-resolver-node@0.3.9", "", { "dependencies": { "debug": "^3.2.7", "is-core-module": "^2.13.0", "resolve": "^1.22.4" } }, "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g=="],
 
@@ -832,7 +840,7 @@
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
-    "flatted": ["flatted@3.4.0", "", {}, "sha512-kC6Bb+ooptOIvWj5B63EQWkF0FEnNjV2ZNkLMLZRDDduIiWeFF4iKnslwhiWxjAdbg4NzTNo6h0qLuvFrcx+Sw=="],
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
@@ -972,7 +980,7 @@
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
-    "jsdom": ["jsdom@29.0.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.0.1", "@asamuzakjp/dom-selector": "^7.0.3", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.1", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.24.5", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg=="],
+    "jsdom": ["jsdom@29.0.2", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.5", "@asamuzakjp/dom-selector": "^7.0.6", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.1", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.24.5", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -1058,7 +1066,7 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
-    "next": ["next@16.2.2", "", { "dependencies": { "@next/env": "16.2.2", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.2", "@next/swc-darwin-x64": "16.2.2", "@next/swc-linux-arm64-gnu": "16.2.2", "@next/swc-linux-arm64-musl": "16.2.2", "@next/swc-linux-x64-gnu": "16.2.2", "@next/swc-linux-x64-musl": "16.2.2", "@next/swc-win32-arm64-msvc": "16.2.2", "@next/swc-win32-x64-msvc": "16.2.2", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-i6AJdyVa4oQjyvX/6GeER8dpY/xlIV+4NMv/svykcLtURJSy/WzDnnUk/TM4d0uewFHK7xSQz4TbIwPgjky+3A=="],
+    "next": ["next@16.2.3", "", { "dependencies": { "@next/env": "16.2.3", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.3", "@next/swc-darwin-x64": "16.2.3", "@next/swc-linux-arm64-gnu": "16.2.3", "@next/swc-linux-arm64-musl": "16.2.3", "@next/swc-linux-x64-gnu": "16.2.3", "@next/swc-linux-x64-musl": "16.2.3", "@next/swc-win32-arm64-msvc": "16.2.3", "@next/swc-win32-x64-msvc": "16.2.3", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA=="],
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
@@ -1112,7 +1120,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
 
@@ -1132,9 +1140,9 @@
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
-    "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
+    "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
-    "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+    "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
@@ -1308,9 +1316,9 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
-    "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+    "vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
 
-    "vitest": ["vitest@4.1.2", "", { "dependencies": { "@vitest/expect": "4.1.2", "@vitest/mocker": "4.1.2", "@vitest/pretty-format": "4.1.2", "@vitest/runner": "4.1.2", "@vitest/snapshot": "4.1.2", "@vitest/spy": "4.1.2", "@vitest/utils": "4.1.2", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.2", "@vitest/browser-preview": "4.1.2", "@vitest/browser-webdriverio": "4.1.2", "@vitest/ui": "4.1.2", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg=="],
+    "vitest": ["vitest@4.1.3", "", { "dependencies": { "@vitest/expect": "4.1.3", "@vitest/mocker": "4.1.3", "@vitest/pretty-format": "4.1.3", "@vitest/runner": "4.1.3", "@vitest/snapshot": "4.1.3", "@vitest/spy": "4.1.3", "@vitest/utils": "4.1.3", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.3", "@vitest/browser-preview": "4.1.3", "@vitest/browser-webdriverio": "4.1.3", "@vitest/coverage-istanbul": "4.1.3", "@vitest/coverage-v8": "4.1.3", "@vitest/ui": "4.1.3", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
@@ -1351,8 +1359,6 @@
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
     "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
-
-    "@asamuzakjp/css-color/lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
@@ -1464,8 +1470,6 @@
 
     "is-bun-module/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
-    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
@@ -1503,13 +1507,5 @@
     "@radix-ui/react-tabs/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-visually-hidden/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
-
-    "glob/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
-
-    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
-
-    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
   }
 }

--- a/coding-standards.md
+++ b/coding-standards.md
@@ -37,6 +37,7 @@ A minimal spec includes:
 - **Edge Cases:** Empty inputs, nulls, concurrent calls, failure modes.
 - **Out of Scope:** Explicit list of what this version does not handle.
 - **Acceptance Criteria:** Checkable statements that prove the implementation is correct.
+- **Test Stubs:** Draft test function names (empty bodies) that map to each acceptance criterion. These ship with the spec, before any implementation begins. Spec approval and test skeleton approval are the same step.
 
 > **Rule:** Code written without a spec is a guess. A spec written after the code is a rationalization. Write it first.
 
@@ -177,7 +178,7 @@ Verification is not an afterthought; it is the single most important factor in o
 
 1. **Define the verification method before coding.** For every non-trivial task, state upfront how correctness will be proven: a test suite, a bash command, a simulator, a browser check, or a diff against expected output.
 2. **Match verification to the domain.** Different work requires different proof:
-   - **Backend logic:** Unit and integration tests, run automatically after each change.
+   - **Backend logic:** For backend logic and business rules, the verification method IS the test suite, and it is written first via the red/green/refactor protocol. Defining "how you will verify" and "writing the failing test" are the same step.
    - **API changes:** curl/httpie commands or integration tests that exercise the endpoint.
    - **Frontend/UI:** Browser testing (e.g., Claude Chrome extension), screenshot comparison, or accessibility audit.
    - **Data pipelines:** Row-count checks, sample-output diffs, schema validation.
@@ -236,6 +237,8 @@ Build incrementally to ensure quality:
 - Run the full test suite after every file modification and fix failures before proceeding.
 - Do not assume code is correct without execution.
 - If tests fail, analyze the failure and diagnose root cause before making changes.
+
+> **Rule:** Each increment is one red/green/refactor cycle. Do not write a second function before the first one has a passing test. Incrementalism without TDD is just small batches of unverified code.
 
 ---
 
@@ -364,6 +367,7 @@ For subagent patterns your team uses repeatedly, define them as reusable agent f
     build-validator.md    # Runs build + tests, reports failures
     code-simplifier.md    # Reviews code for unnecessary complexity
     security-reviewer.md  # Scans for common vulnerability patterns
+    tdd-enforcer.md       # Verifies red/green cycle was followed
     verify-app.md         # End-to-end verification instructions
 ```
 
@@ -377,6 +381,22 @@ isolation: worktree
 Review all changed files for unnecessary complexity, duplicated logic,
 and opportunities to reuse existing utilities. Do not rewrite code;
 return a structured list of findings with file, line, and recommendation.
+```
+
+Example agent definition (`.claude/agents/tdd-enforcer.md`):
+```yaml
+---
+name: tdd-enforcer
+model: sonnet
+---
+You are a strict TDD reviewer. Given a PR diff or a set of changed files:
+1. Verify that every new function or method has a corresponding test.
+2. Verify that tests appear to have been written before implementation
+   (check git history if available).
+3. Flag any logic with no test coverage.
+4. Return a structured report: covered behaviors, uncovered behaviors,
+   and suspected test-after patterns.
+Do not suggest fixes; report findings only.
 ```
 
 **Key practices:**
@@ -430,7 +450,25 @@ When Claude compresses its conversation context, critical instructions can be lo
 ```
 
 **Stop Hook — Verification Gate for Long-Running Tasks:**
-For autonomous, long-running work, use a Stop hook to run deterministic checks (test suite, linter, type checker) before Claude declares a task complete. This ensures Claude cannot mark work as done without passing the verification gate.
+For autonomous, long-running work, use a Stop hook to run deterministic checks (test suite, linter, type checker) before Claude declares a task complete. This ensures Claude cannot mark work as done without passing the verification gate:
+
+```json
+"hooks": {
+  "Stop": [
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "npm test -- --passWithNoTests && npx tsc --noEmit || exit 1"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Replace with your project's test runner and type checker. The `exit 1` blocks Claude from completing until checks pass.
 
 > **Rule:** If a standard can be enforced by a hook, it should be. Human discipline is a backup, not the primary mechanism.
 
@@ -440,11 +478,29 @@ For autonomous, long-running work, use a Stop hook to run deterministic checks (
 
 ### Testing Standards
 
-- Write tests BEFORE implementation when feasible (TDD approach).
-- Test all public APIs and critical paths (target approximately 80% coverage).
-- Use clear behavior-based test names (e.g., `should_return_404_when_user_not_found`).
-- Follow Arrange-Act-Assert pattern.
-- Include positive and negative cases.
+**Red/Green/Refactor is the default workflow. It is not optional.**
+
+The TDD cycle applies to every non-trivial piece of logic:
+
+1. **Red:** Write a failing test that describes the desired behavior. Run it. Confirm it fails for the right reason, not due to a syntax error or missing import.
+2. **Green:** Write the minimal implementation that makes the test pass. No more, no less.
+3. **Refactor:** Clean up the implementation without breaking the test. Extract duplication, improve naming, simplify logic.
+4. **Repeat:** Each new behavior gets its own red/green/refactor cycle before moving on.
+
+> **Rule:** If you cannot write a failing test first, you do not yet understand the requirement well enough to implement it. Stop and clarify.
+
+**Acceptance criteria from the spec ARE the first test cases.** When writing `tasks/spec.md`, each acceptance criterion maps directly to one or more test cases. Claude should draft the test signatures (empty test stubs with behavior-based names) as part of spec finalization, before any implementation begins.
+
+**Coverage targets:**
+- Target approximately 80% line coverage, but coverage is a floor, not a goal.
+- 100% coverage of all acceptance criteria from the spec is required.
+- All edge cases defined in the spec must have explicit tests.
+
+**Test naming:** Use behavior-based names that read like sentences: `should_return_404_when_user_not_found`, not `test_get_user`.
+
+**Arrange-Act-Assert:** Follow this pattern in every test. One assertion concept per test.
+
+**Include both positive and negative cases.**
 
 ### Test Isolation & Strategy
 
@@ -541,7 +597,8 @@ Use the format: `<type>/<short-description>` (e.g., `feat/oauth-login`, `fix/nul
 3. Does this introduce security, performance, or observability regressions?
 4. Is the code readable without the author explaining it?
 5. Are tests present, meaningful, and not testing implementation details?
-6. Are new dependencies justified?
+6. Were tests written before the implementation? (Check commit order if in doubt.)
+7. Are new dependencies justified?
 
 **Review norms:**
 - Respond to review requests within one business day.
@@ -605,6 +662,9 @@ A task is not done when the code works. It is done when ALL of the following are
 **Correctness & Quality:**
 - [ ] The implementation matches the spec or ticket acceptance criteria.
 - [ ] Verification method was defined before coding and passes autonomously.
+- [ ] Tests were written BEFORE implementation (red confirmed before green).
+- [ ] Each acceptance criterion from the spec has at least one corresponding passing test.
+- [ ] Refactor step was completed after green (no dead code, no over-fit logic).
 - [ ] All new and existing tests pass; test suite runs after every modification.
 - [ ] Linting, formatting, and type checking pass with no suppressions.
 - [ ] Type annotations present on all function signatures.
@@ -654,7 +714,9 @@ You are a [role]. I need a spec for [feature].
 Context: [relevant background]
 Constraints: [non-negotiables]
 Anti-goals: [what this should not do]
-Output: A spec in markdown with Goal, Inputs/Outputs, Constraints, Edge Cases, and Acceptance Criteria.
+Output: A spec in markdown with Goal, Inputs/Outputs, Constraints, Edge Cases,
+        Acceptance Criteria, and Test Stubs (empty test function signatures
+        mapping to each acceptance criterion).
 ```
 
 **Implementation prompt:** Use after spec approval.
@@ -662,6 +724,8 @@ Output: A spec in markdown with Goal, Inputs/Outputs, Constraints, Edge Cases, a
 Implement [feature] per this spec: [paste spec]
 Use [language/framework]. Follow the existing patterns in [file or module].
 Do not modify [out-of-scope files].
+Follow red/green/refactor: write the failing test first, confirm it fails,
+then write the minimal implementation to pass.
 Return only the implementation with inline comments explaining non-obvious decisions.
 ```
 
@@ -669,6 +733,7 @@ Return only the implementation with inline comments explaining non-obvious decis
 ```
 Review this code as a skeptical staff engineer.
 Flag: security issues, missing error handling, test gaps, readability problems.
+Also flag: any logic that appears to have been implemented before its tests were written.
 Distinguish blocking issues from suggestions.
 Do not rewrite the code; return a structured list of findings.
 ```
@@ -702,6 +767,7 @@ Avoid these patterns; they produce lower-quality outputs:
 - **Implicit context:** Assuming the model knows your project structure, conventions, or prior decisions without stating them.
 - **Conversational framing on operational tasks:** "Could you please help me understand..." invites verbose responses. For operational asks, write direct commands: "Explain what this function does. List any issues." Claude mirrors the register of its prompts.
 - **Process-defined tasks without exit conditions:** "Keep checking until you find the issue" loops indefinitely. Define outcomes: "Check X. If Y, do Z. If not, report and stop."
+- **Skipping TDD in the prompt:** Not specifying red/green/refactor on implementation prompts invites Claude to write code first and tests after. State it explicitly.
 
 > **Rule:** A prompt is a spec for the model. Apply the same rigor you would to a spec for code.
 
@@ -727,7 +793,22 @@ If you do something more than once a day, it should be a skill or a slash comman
 - Use the `/simplify` pattern after implementation: append a quality-review command to any prompt to run parallel agents that check for reuse, quality, and efficiency in one pass.
 
 **Companion slash commands:**
-This skill ships with `/qspec` (generate a spec) and `/qcheck` (skeptical code review) in `.claude/commands/`. These are the formalized, version-controlled replacements for inline prompt shortcuts.
+This skill ships with `/qspec` (generate a spec), `/qcheck` (skeptical code review), and `/tdd` (start a red/green/refactor cycle) in `.claude/commands/`. These are the formalized, version-controlled replacements for inline prompt shortcuts.
+
+### `/tdd` Slash Command
+
+Start a red/green/refactor cycle for a named behavior.
+
+**Usage:** `/tdd <behavior description>`
+
+Claude will:
+1. Write a failing test stub for the described behavior.
+2. Confirm the test fails for the right reason (not a syntax error or import issue).
+3. Pause for your approval of the test before writing any implementation.
+4. Implement the minimum code to go green.
+5. Propose a refactor pass and await confirmation before committing.
+
+This command enforces the cycle and prevents skipping straight to implementation. Use it at the start of any non-trivial behavior to anchor the work in a verified contract.
 
 ---
 
@@ -739,9 +820,10 @@ Use this template when requesting features:
 
 ```
 Build [feature] that:
+  - Follows red/green/refactor: write failing tests first
   - Uses clear naming
   - Validates inputs, handles errors
-  - Includes tests for core cases
+  - Tests written before implementation (TDD)
   - Follows [framework] conventions
   - Avoids premature abstraction
   - Keeps functions <30 lines
@@ -781,6 +863,12 @@ Build [feature] that:
 - Complex file edits attempted without reading current file state first
 - Agentic tasks defined as a process without a stated outcome condition
 - New dependencies added by Claude in agentic mode without review and lockfile verification
+- Implementation written before any tests existed for non-trivial logic
+- Refactor step skipped after reaching green (technical debt deposited immediately)
+- Test written after implementation to hit a coverage target, not to drive behavior
+- Failing test committed without a corresponding implementation in the same session
+- Acceptance criteria defined in spec but not reflected in any test case
+- Skipping red/green confirmation ("the test would have failed, trust me")
 
 ### Guiding Principle
 
@@ -788,4 +876,4 @@ Build [feature] that:
 
 ---
 
-*Document Version 11.0 | Vinny Carpenter*
+*Document Version 12.0 | Vinny Carpenter*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban-todos-temp",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -43,41 +43,43 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
+    "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "fast-deep-equal": "^3.1.3",
     "lucide-react": "^0.577.0",
-    "next": "^16.2.2",
+    "next": "^16.2.3",
     "next-themes": "^0.4.6",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
-    "@next/bundle-analyzer": "^16.2.2",
+    "@next/bundle-analyzer": "^16.2.3",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4.2.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@types/canvas-confetti": "^1.9.0",
     "@types/node": "^25.5.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.2.0",
-    "baseline-browser-mapping": "^2.10.14",
+    "baseline-browser-mapping": "^2.10.16",
     "eslint": "^9.39.4",
-    "eslint-config-next": "^16.2.2",
+    "eslint-config-next": "^16.2.3",
     "eslint-plugin-react": "^7.37.5",
     "fake-indexeddb": "^6.2.5",
-    "jsdom": "^29.0.1",
+    "jsdom": "^29.0.2",
     "rimraf": "^6.1.3",
     "tailwindcss": "^4.2.2",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.3"
   },
   "overrides": {
     "rollup": "4.59.0",
@@ -86,7 +88,11 @@
     "eslint-plugin-react/minimatch": "3.1.5",
     "@typescript-eslint/typescript-estree/minimatch": "9.0.9",
     "@types/react": "19.2.14",
-    "@types/react-dom": "19.2.3"
+    "@types/react-dom": "19.2.3",
+    "brace-expansion": "^2.0.2",
+    "flatted": "^3.4.2",
+    "picomatch": "^4.0.4",
+    "vite": "^7.3.2"
   },
   "packageManager": "bun@1.3.5"
 }

--- a/sample-export.json
+++ b/sample-export.json
@@ -1,16 +1,16 @@
 {
   "version": "1.0.0",
-  "exportedAt": "2026-03-21T18:30:00.000Z",
+  "exportedAt": "2026-04-07T18:30:00.000Z",
   "boards": [
     {
       "id": "default-board",
       "name": "🚀 Product Launch",
-      "description": "Q1 2026 product launch planning and execution",
+      "description": "Q2 2026 product launch planning and execution",
       "color": "#3b82f6",
       "isDefault": true,
       "order": 0,
       "createdAt": "2026-01-15T09:00:00.000Z",
-      "updatedAt": "2026-03-21T15:30:00.000Z"
+      "updatedAt": "2026-04-07T15:30:00.000Z"
     },
     {
       "id": "work-project-alpha",
@@ -20,27 +20,27 @@
       "isDefault": false,
       "order": 1,
       "createdAt": "2026-02-20T16:20:00.000Z",
-      "updatedAt": "2026-03-21T12:00:00.000Z"
+      "updatedAt": "2026-04-07T12:00:00.000Z"
     },
     {
       "id": "marketing-campaign",
-      "name": "🏠 Home Renovation",
-      "description": "Kitchen remodel and living room updates",
+      "name": "🎯 Marketing Campaign",
+      "description": "Q2 marketing campaign planning and execution",
       "color": "#10b981",
       "isDefault": false,
       "order": 2,
       "createdAt": "2026-01-20T14:00:00.000Z",
-      "updatedAt": "2026-03-20T10:15:00.000Z"
+      "updatedAt": "2026-04-06T10:15:00.000Z"
     },
     {
       "id": "home-improvement",
-      "name": "📚 Learning Goals",
-      "description": "Personal development and skill building",
+      "name": "🏠 Home Renovation",
+      "description": "Kitchen remodel and living room updates",
       "color": "#f59e0b",
       "isDefault": false,
       "order": 3,
       "createdAt": "2026-02-25T11:30:00.000Z",
-      "updatedAt": "2026-03-21T08:45:00.000Z"
+      "updatedAt": "2026-04-07T08:45:00.000Z"
     },
     {
       "id": "side-project",
@@ -50,7 +50,17 @@
       "isDefault": false,
       "order": 4,
       "createdAt": "2026-03-01T13:10:00.000Z",
-      "updatedAt": "2026-03-21T16:22:00.000Z"
+      "updatedAt": "2026-04-07T16:22:00.000Z"
+    },
+    {
+      "id": "learning-goals",
+      "name": "📚 Learning Goals",
+      "description": "Personal development and skill building",
+      "color": "#06b6d4",
+      "isDefault": false,
+      "order": 5,
+      "createdAt": "2026-02-25T11:30:00.000Z",
+      "updatedAt": "2026-04-07T20:45:00.000Z"
     }
   ],
   "tasks": [
@@ -78,8 +88,8 @@
       "tags": ["organization", "photos"],
       "progress": 35,
       "createdAt": "2026-02-28T14:30:00.000Z",
-      "updatedAt": "2026-03-21T10:15:00.000Z",
-      "dueDate": "2026-03-07T17:00:00.000Z"
+      "updatedAt": "2026-04-06T10:15:00.000Z",
+      "dueDate": "2026-04-20T17:00:00.000Z"
     },
     {
       "id": "task-personal-3",
@@ -103,8 +113,8 @@
       "tags": ["learning", "language"],
       "progress": 60,
       "createdAt": "2026-02-27T19:20:00.000Z",
-      "updatedAt": "2026-03-20T20:30:00.000Z",
-      "dueDate": "2026-03-02T17:00:00.000Z"
+      "updatedAt": "2026-04-05T20:30:00.000Z",
+      "dueDate": "2026-04-25T17:00:00.000Z"
     },
     {
       "id": "task-personal-5",
@@ -116,7 +126,7 @@
       "tags": ["insurance", "paperwork"],
       "createdAt": "2026-03-10T13:15:00.000Z",
       "updatedAt": "2026-03-10T13:15:00.000Z",
-      "dueDate": "2026-03-25T17:00:00.000Z"
+      "dueDate": "2026-04-22T17:00:00.000Z"
     },
     {
       "id": "task-personal-6",
@@ -128,7 +138,7 @@
       "tags": ["cleaning", "donation"],
       "createdAt": "2026-03-12T08:45:00.000Z",
       "updatedAt": "2026-03-12T08:45:00.000Z",
-      "dueDate": "2026-03-28T17:00:00.000Z"
+      "dueDate": "2026-04-28T17:00:00.000Z"
     },
     {
       "id": "task-alpha-1",
@@ -152,8 +162,8 @@
       "tags": ["authentication", "security", "backend"],
       "progress": 75,
       "createdAt": "2026-02-26T10:00:00.000Z",
-      "updatedAt": "2026-03-21T15:30:00.000Z",
-      "dueDate": "2026-03-24T17:00:00.000Z"
+      "updatedAt": "2026-04-07T15:30:00.000Z",
+      "dueDate": "2026-04-17T17:00:00.000Z"
     },
     {
       "id": "task-alpha-3",
@@ -165,8 +175,8 @@
       "tags": ["frontend", "responsive", "css"],
       "progress": 40,
       "createdAt": "2026-03-02T11:15:00.000Z",
-      "updatedAt": "2026-03-20T09:20:00.000Z",
-      "dueDate": "2026-03-26T17:00:00.000Z"
+      "updatedAt": "2026-04-06T09:20:00.000Z",
+      "dueDate": "2026-04-21T17:00:00.000Z"
     },
     {
       "id": "task-alpha-4",
@@ -178,7 +188,7 @@
       "tags": ["devops", "ci-cd", "github"],
       "createdAt": "2026-03-08T14:45:00.000Z",
       "updatedAt": "2026-03-08T14:45:00.000Z",
-      "dueDate": "2026-03-28T17:00:00.000Z"
+      "dueDate": "2026-04-24T17:00:00.000Z"
     },
     {
       "id": "task-alpha-5",
@@ -190,7 +200,7 @@
       "tags": ["testing", "api", "backend"],
       "createdAt": "2026-03-10T16:00:00.000Z",
       "updatedAt": "2026-03-10T16:00:00.000Z",
-      "dueDate": "2026-03-31T17:00:00.000Z"
+      "dueDate": "2026-04-28T17:00:00.000Z"
     },
     {
       "id": "task-alpha-6",
@@ -202,7 +212,7 @@
       "tags": ["performance", "images", "optimization"],
       "createdAt": "2026-03-12T12:30:00.000Z",
       "updatedAt": "2026-03-12T12:30:00.000Z",
-      "dueDate": "2026-04-04T17:00:00.000Z"
+      "dueDate": "2026-05-02T17:00:00.000Z"
     },
     {
       "id": "task-alpha-7",
@@ -214,7 +224,7 @@
       "tags": ["documentation", "api"],
       "createdAt": "2026-03-14T09:45:00.000Z",
       "updatedAt": "2026-03-14T09:45:00.000Z",
-      "dueDate": "2026-04-07T17:00:00.000Z"
+      "dueDate": "2026-05-06T17:00:00.000Z"
     },
     {
       "id": "task-marketing-1",
@@ -238,8 +248,8 @@
       "tags": ["design", "social-media", "templates"],
       "progress": 65,
       "createdAt": "2026-02-28T13:00:00.000Z",
-      "updatedAt": "2026-03-21T11:30:00.000Z",
-      "dueDate": "2026-03-25T17:00:00.000Z"
+      "updatedAt": "2026-04-06T11:30:00.000Z",
+      "dueDate": "2026-04-18T17:00:00.000Z"
     },
     {
       "id": "task-marketing-3",
@@ -251,8 +261,8 @@
       "tags": ["email", "automation", "newsletter"],
       "progress": 80,
       "createdAt": "2026-03-04T15:45:00.000Z",
-      "updatedAt": "2026-03-21T10:15:00.000Z",
-      "dueDate": "2026-03-23T17:00:00.000Z"
+      "updatedAt": "2026-04-07T10:15:00.000Z",
+      "dueDate": "2026-04-15T17:00:00.000Z"
     },
     {
       "id": "task-marketing-4",
@@ -264,7 +274,7 @@
       "tags": ["research", "competitors", "analysis"],
       "createdAt": "2026-03-06T09:20:00.000Z",
       "updatedAt": "2026-03-06T09:20:00.000Z",
-      "dueDate": "2026-03-28T17:00:00.000Z"
+      "dueDate": "2026-04-20T17:00:00.000Z"
     },
     {
       "id": "task-marketing-5",
@@ -276,7 +286,7 @@
       "tags": ["video", "testimonials", "customers"],
       "createdAt": "2026-03-08T16:30:00.000Z",
       "updatedAt": "2026-03-08T16:30:00.000Z",
-      "dueDate": "2026-04-10T17:00:00.000Z"
+      "dueDate": "2026-05-10T17:00:00.000Z"
     },
     {
       "id": "task-marketing-6",
@@ -288,7 +298,7 @@
       "tags": ["influencers", "partnerships", "outreach"],
       "createdAt": "2026-03-10T12:15:00.000Z",
       "updatedAt": "2026-03-10T12:15:00.000Z",
-      "dueDate": "2026-04-01T17:00:00.000Z"
+      "dueDate": "2026-04-30T17:00:00.000Z"
     },
     {
       "id": "task-home-1",
@@ -312,8 +322,8 @@
       "tags": ["lighting", "electrical", "installation"],
       "progress": 50,
       "createdAt": "2026-02-28T10:30:00.000Z",
-      "updatedAt": "2026-03-20T15:20:00.000Z",
-      "dueDate": "2026-03-25T17:00:00.000Z"
+      "updatedAt": "2026-04-05T15:20:00.000Z",
+      "dueDate": "2026-04-19T17:00:00.000Z"
     },
     {
       "id": "task-home-3",
@@ -325,8 +335,8 @@
       "tags": ["landscaping", "design", "backyard"],
       "progress": 25,
       "createdAt": "2026-03-04T12:45:00.000Z",
-      "updatedAt": "2026-03-18T14:10:00.000Z",
-      "dueDate": "2026-04-15T17:00:00.000Z"
+      "updatedAt": "2026-04-02T14:10:00.000Z",
+      "dueDate": "2026-05-15T17:00:00.000Z"
     },
     {
       "id": "task-home-4",
@@ -338,7 +348,7 @@
       "tags": ["painting", "bedroom", "interior"],
       "createdAt": "2026-03-07T09:15:00.000Z",
       "updatedAt": "2026-03-07T09:15:00.000Z",
-      "dueDate": "2026-03-29T17:00:00.000Z"
+      "dueDate": "2026-04-29T17:00:00.000Z"
     },
     {
       "id": "task-home-5",
@@ -350,7 +360,7 @@
       "tags": ["plumbing", "bathroom", "fixtures"],
       "createdAt": "2026-03-08T11:40:00.000Z",
       "updatedAt": "2026-03-08T11:40:00.000Z",
-      "dueDate": "2026-04-05T17:00:00.000Z"
+      "dueDate": "2026-05-05T17:00:00.000Z"
     },
     {
       "id": "task-home-6",
@@ -362,52 +372,52 @@
       "tags": ["organization", "garage", "storage"],
       "createdAt": "2026-03-12T13:25:00.000Z",
       "updatedAt": "2026-03-12T13:25:00.000Z",
-      "dueDate": "2026-04-01T17:00:00.000Z"
+      "dueDate": "2026-05-01T17:00:00.000Z"
     },
     {
       "id": "task-learning-1",
       "title": "Complete React Advanced Patterns course",
       "description": "Finish all modules and build the final project",
       "status": "in-progress",
-      "boardId": "home-improvement",
+      "boardId": "learning-goals",
       "priority": "high",
       "tags": ["react", "course", "frontend"],
       "progress": 70,
       "createdAt": "2026-02-25T09:00:00.000Z",
-      "updatedAt": "2026-03-21T19:15:00.000Z",
-      "dueDate": "2026-03-28T17:00:00.000Z"
+      "updatedAt": "2026-04-07T19:15:00.000Z",
+      "dueDate": "2026-04-26T17:00:00.000Z"
     },
     {
       "id": "task-learning-2",
       "title": "Read 'Clean Architecture' book",
       "description": "Study software design principles and patterns",
       "status": "in-progress",
-      "boardId": "home-improvement",
+      "boardId": "learning-goals",
       "priority": "medium",
       "tags": ["reading", "architecture", "software-design"],
       "progress": 45,
       "createdAt": "2026-03-02T20:30:00.000Z",
-      "updatedAt": "2026-03-20T21:00:00.000Z",
-      "dueDate": "2026-04-15T17:00:00.000Z"
+      "updatedAt": "2026-04-06T21:00:00.000Z",
+      "dueDate": "2026-05-15T17:00:00.000Z"
     },
     {
       "id": "task-learning-3",
       "title": "Practice TypeScript advanced features",
       "description": "Master generics, utility types, and conditional types",
       "status": "todo",
-      "boardId": "home-improvement",
+      "boardId": "learning-goals",
       "priority": "high",
       "tags": ["typescript", "programming", "practice"],
       "createdAt": "2026-03-07T18:45:00.000Z",
       "updatedAt": "2026-03-07T18:45:00.000Z",
-      "dueDate": "2026-03-31T17:00:00.000Z"
+      "dueDate": "2026-04-30T17:00:00.000Z"
     },
     {
       "id": "task-learning-4",
       "title": "Attend GraphQL workshop",
       "description": "Learn advanced GraphQL patterns and best practices",
       "status": "done",
-      "boardId": "home-improvement",
+      "boardId": "learning-goals",
       "priority": "medium",
       "tags": ["graphql", "workshop", "api"],
       "createdAt": "2026-03-08T10:20:00.000Z",
@@ -419,37 +429,37 @@
       "title": "Build CLI tool with Node.js",
       "description": "Create a command-line utility for personal productivity",
       "status": "todo",
-      "boardId": "home-improvement",
+      "boardId": "learning-goals",
       "priority": "low",
       "tags": ["nodejs", "cli", "project"],
       "createdAt": "2026-03-10T17:10:00.000Z",
       "updatedAt": "2026-03-10T17:10:00.000Z",
-      "dueDate": "2026-04-30T17:00:00.000Z"
+      "dueDate": "2026-05-30T17:00:00.000Z"
     },
     {
       "id": "task-learning-6",
       "title": "Learn Docker containerization",
       "description": "Master container creation, orchestration, and deployment",
       "status": "todo",
-      "boardId": "home-improvement",
+      "boardId": "learning-goals",
       "priority": "medium",
       "tags": ["docker", "devops", "containers"],
       "createdAt": "2026-03-12T14:55:00.000Z",
       "updatedAt": "2026-03-12T14:55:00.000Z",
-      "dueDate": "2026-04-10T17:00:00.000Z"
+      "dueDate": "2026-05-10T17:00:00.000Z"
     },
     {
       "id": "task-learning-7",
       "title": "Complete AWS certification prep",
       "description": "Study for AWS Solutions Architect Associate exam",
       "status": "in-progress",
-      "boardId": "home-improvement",
+      "boardId": "learning-goals",
       "priority": "high",
       "tags": ["aws", "certification", "cloud"],
       "progress": 30,
       "createdAt": "2026-03-04T08:30:00.000Z",
-      "updatedAt": "2026-03-21T20:45:00.000Z",
-      "dueDate": "2026-04-20T17:00:00.000Z"
+      "updatedAt": "2026-04-07T20:45:00.000Z",
+      "dueDate": "2026-05-20T17:00:00.000Z"
     },
     {
       "id": "task-side-1",
@@ -485,8 +495,8 @@
       "tags": ["development", "features", "crud"],
       "progress": 60,
       "createdAt": "2026-03-07T09:30:00.000Z",
-      "updatedAt": "2026-03-21T16:20:00.000Z",
-      "dueDate": "2026-03-25T17:00:00.000Z"
+      "updatedAt": "2026-04-07T16:20:00.000Z",
+      "dueDate": "2026-04-18T17:00:00.000Z"
     },
     {
       "id": "task-side-4",
@@ -498,8 +508,8 @@
       "tags": ["auth", "security", "oauth"],
       "progress": 40,
       "createdAt": "2026-03-08T11:45:00.000Z",
-      "updatedAt": "2026-03-20T14:10:00.000Z",
-      "dueDate": "2026-03-28T17:00:00.000Z"
+      "updatedAt": "2026-04-05T14:10:00.000Z",
+      "dueDate": "2026-04-24T17:00:00.000Z"
     },
     {
       "id": "task-side-5",
@@ -511,7 +521,7 @@
       "tags": ["mobile", "responsive", "ui"],
       "createdAt": "2026-03-10T15:20:00.000Z",
       "updatedAt": "2026-03-10T15:20:00.000Z",
-      "dueDate": "2026-04-01T17:00:00.000Z"
+      "dueDate": "2026-05-01T17:00:00.000Z"
     },
     {
       "id": "task-side-6",
@@ -523,7 +533,7 @@
       "tags": ["analytics", "monitoring", "tracking"],
       "createdAt": "2026-03-12T10:35:00.000Z",
       "updatedAt": "2026-03-12T10:35:00.000Z",
-      "dueDate": "2026-04-15T17:00:00.000Z"
+      "dueDate": "2026-05-15T17:00:00.000Z"
     },
     {
       "id": "task-side-7",
@@ -535,7 +545,7 @@
       "tags": ["deployment", "hosting", "production"],
       "createdAt": "2026-03-14T12:50:00.000Z",
       "updatedAt": "2026-03-14T12:50:00.000Z",
-      "dueDate": "2026-04-10T17:00:00.000Z"
+      "dueDate": "2026-05-10T17:00:00.000Z"
     },
     {
       "id": "task-side-8",
@@ -547,7 +557,7 @@
       "tags": ["documentation", "guides", "help"],
       "createdAt": "2026-03-15T14:25:00.000Z",
       "updatedAt": "2026-03-15T14:25:00.000Z",
-      "dueDate": "2026-04-25T17:00:00.000Z"
+      "dueDate": "2026-05-25T17:00:00.000Z"
     }
   ],
   "settings": {

--- a/scripts/validate-sample.ts
+++ b/scripts/validate-sample.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'fs';
+import { validateExportData, validateDataRelationships } from '../src/lib/utils/validation';
+import { deserializeTask, deserializeBoard } from '../src/lib/utils/exportImport/serialize';
+
+const file = process.argv[2] ?? 'sample-export.json';
+const data = JSON.parse(readFileSync(file, 'utf-8'));
+
+const schema = validateExportData(data);
+const rel = validateDataRelationships(data);
+
+console.log('Schema valid:', schema.isValid, '| errors:', schema.errors.length, '| warnings:', schema.warnings.length);
+console.log('Relationships valid:', rel.isValid, '| errors:', rel.errors.length, '| warnings:', rel.warnings.length);
+
+let deserializeErrors = 0;
+for (const t of data.tasks) {
+  try { deserializeTask(t); } catch (e) { deserializeErrors++; console.log('task', t.id, e); }
+}
+for (const b of data.boards) {
+  try { deserializeBoard(b); } catch (e) { deserializeErrors++; console.log('board', b.id, e); }
+}
+console.log('Deserialize errors:', deserializeErrors);

--- a/src/components/DragDropProvider.tsx
+++ b/src/components/DragDropProvider.tsx
@@ -16,6 +16,7 @@ import {
 } from "@dnd-kit/core";
 import { Task } from "@/lib/types";
 import { useTaskStore } from "@/lib/stores/taskStore";
+import { celebrateTaskCompletion } from "@/lib/utils/celebrateCompletion";
 import TaskCard from "./kanban/TaskCard";
 
 // Cache touch detection once at module level with SSR guard
@@ -77,7 +78,13 @@ export function DragDropProvider({
       const newStatus = over.id as Task['status'];
 
       if (newStatus && ['todo', 'in-progress', 'done'].includes(newStatus)) {
+        // Celebrate only real transitions into 'done' (not done → done drops).
+        const previousStatus = tasks.find((t: Task) => t.id === taskId)?.status;
         moveTask(taskId, newStatus);
+        if (newStatus === 'done' && previousStatus && previousStatus !== 'done') {
+          const completedTitle = tasks.find((t: Task) => t.id === taskId)?.title ?? '';
+          celebrateTaskCompletion(completedTitle);
+        }
       }
     }
 

--- a/src/lib/utils/celebrateCompletion.ts
+++ b/src/lib/utils/celebrateCompletion.ts
@@ -1,0 +1,67 @@
+import { toast } from 'sonner';
+import type { CreateTypes } from 'canvas-confetti';
+import { useSettingsStore } from '@/lib/stores/settingsStore';
+
+/**
+ * Fires a confetti burst + toast when a task is completed.
+ *
+ * Why: purely-visual reward lives at the UI layer so the store stays side-effect free.
+ * canvas-confetti is loaded on-demand to keep it out of the initial bundle, matching
+ * the project's lazy-loading pattern for non-critical UI deps.
+ *
+ * CSP note: the default `confetti()` export spawns a Web Worker from a blob: URL, which
+ * is blocked by our production CSP (`script-src 'self' 'unsafe-inline'`, no `worker-src`).
+ * We use `confetti.create(canvas, { useWorker: false })` against an overlay canvas we own,
+ * so the animation runs on the main thread and never hits worker/blob policy.
+ */
+let confettiInstance: CreateTypes | null = null;
+
+async function getConfetti(): Promise<CreateTypes | null> {
+  if (confettiInstance) return confettiInstance;
+  if (typeof document === 'undefined') return null;
+
+  const { default: confetti } = await import('canvas-confetti');
+
+  const canvas = document.createElement('canvas');
+  canvas.setAttribute('aria-hidden', 'true');
+  Object.assign(canvas.style, {
+    position: 'fixed',
+    inset: '0',
+    width: '100%',
+    height: '100%',
+    pointerEvents: 'none',
+    zIndex: '9999',
+  });
+  document.body.appendChild(canvas);
+
+  confettiInstance = confetti.create(canvas, { resize: true, useWorker: false });
+  return confettiInstance;
+}
+
+export async function celebrateTaskCompletion(taskTitle: string): Promise<void> {
+  toast.success('Task completed', {
+    description: taskTitle,
+  });
+
+  if (shouldSkipMotion()) return;
+
+  try {
+    const fire = await getConfetti();
+    if (!fire) return;
+    fire({
+      particleCount: 80,
+      spread: 70,
+      startVelocity: 35,
+      origin: { y: 0.7 },
+      disableForReducedMotion: true,
+    });
+  } catch {
+    // Confetti is non-essential — swallow load/runtime failures silently.
+  }
+}
+
+function shouldSkipMotion(): boolean {
+  if (useSettingsStore.getState().settings.accessibility?.reduceMotion) return true;
+  if (typeof window === 'undefined') return true;
+  return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+}


### PR DESCRIPTION
## Summary
- **Confetti on task completion** — adds `canvas-confetti` burst alongside the sonner toast when a task transitions into Done via drag-and-drop. Lives in a new `celebrateCompletion.ts` helper that's dynamic-imported, honors `settings.accessibility.reduceMotion` + `prefers-reduced-motion`, and uses `confetti.create(useWorker: false)` against an owned overlay canvas so it works under the production CSP (`script-src 'self' 'unsafe-inline'` with no `worker-src`/`blob:`). Wired into `DragDropProvider` to fire only on real `!done → done` transitions.
- **Dependency audit cleanup** — `bun update` + new transitive overrides for `brace-expansion`, `flatted`, `picomatch`, and `vite`. Clears all 10 vulnerabilities previously surfaced by `bun audit` (5 high, 5 moderate).
- **sample-export.json refresh** — updates `exportedAt`, shifts 23 past-due open task `dueDate`s to future dates, fixes swapped board names (`marketing-campaign` → "🎯 Marketing Campaign", `home-improvement` → "🏠 Home Renovation"), adds the missing `learning-goals` board and repoints all `task-learning-*` tasks to it. Schema, relationship, and deserialization validators all pass with 0 errors/warnings.
- **Validation script** — adds `scripts/validate-sample.ts` so the sample export can be re-checked against the real validators on demand.
- Bumps version to 4.5.0.

## Test plan
- [ ] `bun run lint` passes
- [ ] `bun audit` reports no vulnerabilities
- [ ] `bun scripts/validate-sample.ts` reports schema/relationships valid + 0 deserialize errors
- [ ] Drag a todo/in-progress card to Done → confetti burst fires and toast appears
- [ ] Drag a done card within the Done column → no duplicate confetti/toast
- [ ] With OS `prefers-reduced-motion: reduce` (or settings `reduceMotion: true`) → toast still fires, no confetti
- [ ] Deploy to prod and verify no CSP error in console (`Creating a worker from 'blob:...'` should be gone)
- [ ] Import `sample-export.json` via the Import dialog on a fresh board set → 6 boards, tasks distributed correctly, no overdue badges on open tasks