### PR TITLE
fix(tests): restore green CI by repairing tsc + runtime test regressions

### DIFF
--- a/e2e/crossBoardSearch.spec.ts
+++ b/e2e/crossBoardSearch.spec.ts
@@ -318,7 +318,7 @@ async function createLargeDataset(page: any) {
 
 async function deleteBoardWithTasks(page: any, boardName: string) {
   // Navigate to board management and delete a board
-  await page.evaluate((name) => {
+  await page.evaluate((name: string) => {
     // This would trigger board deletion through the app's interface
     console.log(`Deleting board: ${name}`);
   }, boardName);

--- a/src/components/__tests__/BoardReordering.ios.test.tsx
+++ b/src/components/__tests__/BoardReordering.ios.test.tsx
@@ -69,7 +69,7 @@ describe('Board Reordering iOS Tests', () => {
     vi.clearAllMocks()
 
     // Mock useBoardStore
-    ;(useBoardStore as ReturnType<typeof vi.fn>).mockReturnValue({
+    ;(useBoardStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
       boards: mockBoards,
       currentBoardId: 'board-1',
       selectBoard: mockSelectBoard,
@@ -77,12 +77,12 @@ describe('Board Reordering iOS Tests', () => {
     })
 
     // Mock useTaskStore
-    ;(useTaskStore as ReturnType<typeof vi.fn>).mockReturnValue({
+    ;(useTaskStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
       tasks: [],
     })
 
     // Mock useSettingsStore
-    ;(useSettingsStore as ReturnType<typeof vi.fn>).mockReturnValue({
+    ;(useSettingsStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
       settings: {
         theme: 'light',
         autoArchiveDays: 30,
@@ -231,7 +231,8 @@ describe('Board Reordering iOS Tests', () => {
       const activeBoardCard = screen.getByText('First Board').closest('.group')
       
       if (activeBoardCard) {
-        expect(activeBoardCard.className).toContain('ring-2 ring-primary')
+        // Active board is marked via the `sidebar-item--active` class on the BoardItem root.
+        expect(activeBoardCard.className).toContain('sidebar-item--active')
       }
     })
   })

--- a/src/components/__tests__/DragDropProvider.ios.test.tsx
+++ b/src/components/__tests__/DragDropProvider.ios.test.tsx
@@ -37,7 +37,7 @@ describe('DragDropProvider iOS TouchSensor Tests', () => {
     vi.clearAllMocks()
     
     // Mock useTaskStore implementation
-    ;(useTaskStore as ReturnType<typeof vi.fn>).mockReturnValue({
+    ;(useTaskStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
       tasks: mockTasks,
       moveTask: mockMoveTask,
     })

--- a/src/components/__tests__/SearchBar.integration.test.tsx
+++ b/src/components/__tests__/SearchBar.integration.test.tsx
@@ -79,7 +79,7 @@ interface MockTaskStore {
 }
 
 interface MockSettingsStore {
-  settings: Settings;
+  settings: Pick<Settings, 'searchPreferences'>;
   updateSettings: ReturnType<typeof vi.fn>;
 }
 
@@ -120,9 +120,9 @@ describe('SearchBar Integration Tests', () => {
 
     // Mock the getState method to return the mock store
     mockGetState.mockReturnValue(mockTaskStore);
-    (useTaskStore as ReturnType<typeof vi.fn>).mockReturnValue(mockTaskStore);
-    (useTaskStore as ReturnType<typeof vi.fn>).getState = mockGetState;
-    (useSettingsStore as ReturnType<typeof vi.fn>).mockReturnValue(mockSettingsStore);
+    (useTaskStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue(mockTaskStore);
+    (useTaskStore as unknown as ReturnType<typeof vi.fn> & { getState: typeof mockGetState }).getState = mockGetState;
+    (useSettingsStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue(mockSettingsStore);
 
     vi.clearAllMocks();
   });

--- a/src/components/__tests__/SearchBar.test.tsx
+++ b/src/components/__tests__/SearchBar.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SearchBar } from '../SearchBar';
+import type { TaskFilters } from '@/lib/types';
 
 // Mock the stores
 const mockSetFilters = vi.fn();
@@ -16,7 +17,7 @@ const mockTaskStore = {
     crossBoardSearch: false,
     status: undefined,
     priority: undefined,
-  },
+  } as TaskFilters,
   setFilters: mockSetFilters,
   setCrossBoardSearch: mockSetCrossBoardSearch,
   clearFilters: mockClearFilters,

--- a/src/components/__tests__/accessibility.test.tsx
+++ b/src/components/__tests__/accessibility.test.tsx
@@ -80,6 +80,8 @@ const mockBoard: Board = {
   id: 'board-1',
   name: 'Test Board',
   color: '#3b82f6',
+  isDefault: false,
+  order: 0,
   createdAt: new Date(),
   updatedAt: new Date(),
 };

--- a/src/components/kanban/__tests__/TaskCard.test.tsx
+++ b/src/components/kanban/__tests__/TaskCard.test.tsx
@@ -45,8 +45,9 @@ describe('TaskCard', () => {
 
   it('shows priority badge correctly', () => {
     render(<TaskCard task={mockTask} />)
-    
-    expect(screen.getByText('medium')).toBeInTheDocument()
+
+    // Priority is exposed via a screen-reader-only label in the form "Priority: medium".
+    expect(screen.getByText(/priority:\s*medium/i)).toBeInTheDocument()
   })
 
   it('renders task tags', () => {


### PR DESCRIPTION
## Summary
- Fixes a long-standing red CI on `main`: every merge since #48 has failed the `Lint, Type Check & Test` job on `tsc --noEmit`, plus two runtime test failures were masked behind the tsc exit.
- No product code changed — only test files and one e2e helper. Production build (`bun run build`) still clean.

## Root causes & fixes
1. **Vitest `Mock<Procedure | Constructable>` tightened** — direct casts from Zustand's `UseBoundStore<…>` to `ReturnType<typeof vi.fn>` now error. Fix: route through `unknown` (`as unknown as ReturnType<typeof vi.fn>`), exactly as the TS error text suggests. Touches `BoardReordering.ios.test.tsx`, `DragDropProvider.ios.test.tsx`, `SearchBar.integration.test.tsx`.
2. **Over-strict `MockSettingsStore.settings: Settings`** in `SearchBar.integration.test.tsx` — narrow to `Pick<Settings, 'searchPreferences'>` since the test only reads that field.
3. **Inference too narrow in `SearchBar.test.tsx`** — `tags: []` was inferred as `never[]`, `status: undefined` as literal `undefined`, blocking later reassignments. Cast the filters object to `TaskFilters`.
4. **`accessibility.test.tsx` `mockBoard`** missing required `isDefault` / `order`.
5. **`e2e/crossBoardSearch.spec.ts`** — implicit-any param on `deleteBoardWithTasks`' inner callback.
6. **Stale runtime expectations** (were masked behind the tsc failure):
   - `TaskCard.test.tsx` expected a bare `medium` badge text, but priority is now exposed via an `sr-only` `Priority: medium` label.
   - `BoardReordering.ios.test.tsx` expected `ring-2 ring-primary`, but active board state now uses the `sidebar-item--active` class.

## Test plan
- [x] `bun run tsc --noEmit` — clean
- [x] `bun run lint` — 0 errors (64 pre-existing warnings, unchanged by this PR)
- [x] `bun run test` — 19/19 files, 360/360 tests passing
- [x] `bun run build` — static export completes
- [ ] CI green on this PR confirming the same across ubuntu-latest