### PR TITLE
security: implement security review recommendations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,28 @@
-# Multi-stage build: build static export, serve with nginx (non-root)
+# Multi-stage build: build static export with Bun, serve with nginx (non-root)
 
-# 1) Builder: install deps and build static site to /app/out
+# 1) Builder: install deps with the same package manager as CI (bun) and build
 FROM node:20-bookworm-slim AS builder
 WORKDIR /app
 ENV NODE_ENV=production
 
-# Install dependencies using lockfile
-COPY package.json package-lock.json* ./
-RUN npm ci --no-audit --no-fund
+# Install Bun (matches `packageManager` pin in package.json and CI).
+# `git` is needed by the `next build` script's NEXT_PUBLIC_BUILD_HASH=$(git rev-parse ...)
+# fallback; without it the env var falls back to "dev" which is fine but git is small.
+ARG BUN_VERSION=1.3.5
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl unzip ca-certificates git \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
+ENV PATH="/root/.bun/bin:${PATH}"
 
-# Copy source and build
+# Install dependencies from the bun lockfile, with no lifecycle scripts so a
+# compromised transitive dep cannot run code in the build container.
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --ignore-scripts
+
+# Copy source and build static export to /app/out
 COPY . .
-RUN npm run build
+RUN bun run build
 
 # 2) Runner: nginx to serve static assets
 FROM nginx:alpine AS runner
@@ -19,8 +30,12 @@ FROM nginx:alpine AS runner
 # Copy exported site
 COPY --from=builder /app/out /usr/share/nginx/html
 
-# Provide nginx config (cache static assets, single-page routing)
+# Provide nginx config (cache static assets, single-page routing, security headers).
+# nginx's `add_header` does not inherit into nested location blocks that define
+# their own `add_header`, so the security headers live in a snippet that each
+# block `include`s explicitly.
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY docker/security-headers.conf /etc/nginx/security-headers.conf
 
 # Run as non-root on high port
 USER nginx

--- a/bun.lock
+++ b/bun.lock
@@ -71,6 +71,7 @@
     "eslint-plugin-react/minimatch": "3.1.5",
     "flatted": "^3.4.2",
     "picomatch": "^4.0.4",
+    "postcss": "^8.4.49",
     "rollup": "4.59.0",
     "vite": "^7.3.2",
   },
@@ -1500,8 +1501,6 @@
     "loose-envify/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "make-dir/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
-    "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,6 +1,10 @@
 server {
   listen 8080;
   server_name _;
+
+  # Don't leak the nginx version in `Server` headers / error pages.
+  server_tokens off;
+
   root /usr/share/nginx/html;
   index index.html;
 
@@ -20,12 +24,14 @@ server {
   location / {
     try_files $uri $uri/ /index.html;
     # Avoid caching HTML to ensure fresh navigation
-    add_header Cache-Control "no-store";
+    add_header Cache-Control "no-store" always;
+    include /etc/nginx/security-headers.conf;
   }
 
   # Cache-bust static assets aggressively (filenames are content-hashed)
   location ~* \.(?:js|css|svg|png|jpg|jpeg|gif|webp|ico|woff2?)$ {
-    add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+    include /etc/nginx/security-headers.conf;
   }
 }
 

--- a/docker/security-headers.conf
+++ b/docker/security-headers.conf
@@ -1,0 +1,25 @@
+# Security response headers for the self-hosted Docker deployment.
+#
+# These mirror the CloudFront response-headers policy applied to
+# todos.vinny.dev / cascade.vinny.dev (see docs/security-headers-baseline.json
+# and scripts/update-security-headers.sh) so behaviour is consistent across
+# both deployment paths.
+#
+# This file is `include`d from each `location` block in nginx.conf because
+# nginx does not inherit server-level `add_header` directives into nested
+# locations that define their own `add_header`.
+
+add_header X-Frame-Options          "DENY"                                          always;
+add_header X-Content-Type-Options   "nosniff"                                       always;
+add_header Referrer-Policy          "strict-origin-when-cross-origin"               always;
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains"          always;
+add_header Permissions-Policy       "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()" always;
+# Content-Security-Policy:
+# - 'unsafe-inline' in script-src is currently required by Next.js App Router
+#   static export: the build emits inline <script> tags for next-themes
+#   anti-FOUC, RSC payload hydration (`self.__next_f.push(...)`), and the
+#   Next.js error page. Tightening this further requires a per-page hash
+#   pipeline; track in a follow-up.
+# - 'unsafe-inline' in style-src covers inline `style="..."` attributes used
+#   throughout the components (e.g. TaskDialog presets, TaskCard typography).
+add_header Content-Security-Policy  "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; worker-src 'self'; upgrade-insecure-requests" always;

--- a/docs/security-headers-baseline.json
+++ b/docs/security-headers-baseline.json
@@ -11,6 +11,11 @@
     "permissions-policy": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()"
   },
   "csp": {
+    "_notes": [
+      "script-src and style-src include 'unsafe-inline' because Next.js App Router static export emits inline <script> tags for next-themes anti-FOUC, RSC payload hydration (self.__next_f.push(...)), and the Next.js error page. Tightening this further (via 'strict-dynamic' + per-page hashes) is tracked as a follow-up.",
+      "worker-src 'self' is required because the PWA registers a service worker (/sw.js).",
+      "upgrade-insecure-requests rewrites any accidental http:// asset URLs to https:// at the browser, blocking mixed-content downgrades."
+    ],
     "requiredDirectives": [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline'",
@@ -20,7 +25,9 @@
       "object-src 'none'",
       "base-uri 'self'",
       "form-action 'self'",
-      "frame-ancestors 'none'"
+      "frame-ancestors 'none'",
+      "worker-src 'self'",
+      "upgrade-insecure-requests"
     ],
     "disallowedTokens": [
       "'unsafe-eval'",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,10 @@ const eslintConfig = [
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-non-null-assertion": "warn",
       "@typescript-eslint/explicit-function-return-type": "off",
+      // Forbid dangerouslySetInnerHTML so we can't accidentally introduce an
+      // XSS sink. React's auto-escaping is the only XSS defence we rely on;
+      // see src/lib/utils/security.ts for the broader threat model.
+      "react/no-danger": "error",
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "brace-expansion": "^2.0.2",
     "flatted": "^3.4.2",
     "picomatch": "^4.0.4",
+    "postcss": "^8.4.49",
     "vite": "^7.3.2"
   },
   "packageManager": "bun@1.3.5"

--- a/scripts/deploy-multi.sh
+++ b/scripts/deploy-multi.sh
@@ -1,14 +1,21 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Multi-Environment Deployment Script for Cascade Kanban
 # Supports deployment to multiple S3 buckets and CloudFront distributions
 
-set -e  # Exit on any error
+# -e:        exit on any non-zero command
+# -u:        treat unset variables as an error
+# -o pipefail: a pipeline returns the first non-zero exit code, not the last
+set -euo pipefail
 
 # Default configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 CONFIG_FILE="$PROJECT_DIR/deploy-config.json"
+
+# Optional flag controlled by --wait-invalidation. Default to empty so `set -u`
+# doesn't trip when checking it.
+WAIT_FOR_INVALIDATION="${WAIT_FOR_INVALIDATION:-}"
 
 # Colors for output
 RED='\033[0;31m'
@@ -38,28 +45,36 @@ info() {
 # Function to load environment configuration
 load_config() {
     local env_name="$1"
-    
+
     if [ ! -f "$CONFIG_FILE" ]; then
         error "Configuration file not found: $CONFIG_FILE"
     fi
-    
+
     if ! command -v jq &> /dev/null; then
         error "jq is not installed. Please install jq to parse JSON configuration."
     fi
-    
-    # Check if environment exists
-    if ! jq -e ".environments.$env_name" "$CONFIG_FILE" > /dev/null; then
+
+    # Reject anything outside [a-zA-Z0-9_-] before interpolating into the jq
+    # filter. This isn't an exposed-to-the-internet path, but it stops typos
+    # like `--cascade` from being treated as a jq operator.
+    if ! [[ "$env_name" =~ ^[A-Za-z0-9_-]+$ ]]; then
+        error "Invalid environment name: '$env_name' (must match [A-Za-z0-9_-]+)"
+    fi
+
+    # Check if environment exists. Use --arg to interpolate safely.
+    if ! jq -e --arg env "$env_name" '.environments[$env]' "$CONFIG_FILE" > /dev/null; then
         error "Environment '$env_name' not found in configuration"
     fi
-    
+
     # Load environment variables
-    export ENV_NAME=$(jq -r ".environments.$env_name.name" "$CONFIG_FILE")
-    export S3_BUCKET=$(jq -r ".environments.$env_name.s3_bucket" "$CONFIG_FILE")
-    export CLOUDFRONT_DISTRIBUTION_ID=$(jq -r ".environments.$env_name.cloudfront_distribution_id" "$CONFIG_FILE")
-    export DOMAIN=$(jq -r ".environments.$env_name.domain" "$CONFIG_FILE")
-    export SECURITY_HEADERS_POLICY_ID=$(jq -r ".environments.$env_name.security_headers_policy_id" "$CONFIG_FILE")
-    export DESCRIPTION=$(jq -r ".environments.$env_name.description" "$CONFIG_FILE")
-    
+    ENV_NAME="$(jq -r --arg env "$env_name" '.environments[$env].name' "$CONFIG_FILE")"
+    S3_BUCKET="$(jq -r --arg env "$env_name" '.environments[$env].s3_bucket' "$CONFIG_FILE")"
+    CLOUDFRONT_DISTRIBUTION_ID="$(jq -r --arg env "$env_name" '.environments[$env].cloudfront_distribution_id' "$CONFIG_FILE")"
+    DOMAIN="$(jq -r --arg env "$env_name" '.environments[$env].domain' "$CONFIG_FILE")"
+    SECURITY_HEADERS_POLICY_ID="$(jq -r --arg env "$env_name" '.environments[$env].security_headers_policy_id' "$CONFIG_FILE")"
+    DESCRIPTION="$(jq -r --arg env "$env_name" '.environments[$env].description' "$CONFIG_FILE")"
+    export ENV_NAME S3_BUCKET CLOUDFRONT_DISTRIBUTION_ID DOMAIN SECURITY_HEADERS_POLICY_ID DESCRIPTION
+
     info "Loaded configuration for environment: $ENV_NAME"
     info "Target domain: $DOMAIN"
     info "S3 bucket: $S3_BUCKET"
@@ -69,9 +84,10 @@ load_config() {
 # Function to show available environments
 show_environments() {
     echo "Available environments:"
-    jq -r '.environments | keys[]' "$CONFIG_FILE" | while read env; do
-        name=$(jq -r ".environments.$env.name" "$CONFIG_FILE")
-        desc=$(jq -r ".environments.$env.description" "$CONFIG_FILE")
+    jq -r '.environments | keys[]' "$CONFIG_FILE" | while read -r env; do
+        local name desc
+        name="$(jq -r --arg env "$env" '.environments[$env].name' "$CONFIG_FILE")"
+        desc="$(jq -r --arg env "$env" '.environments[$env].description' "$CONFIG_FILE")"
         echo "  $env: $name - $desc"
     done
 }
@@ -124,12 +140,12 @@ build_app() {
 # Deploy to S3
 deploy_to_s3() {
     log "Deploying to S3 ($S3_BUCKET)..."
-    
+
     cd "$PROJECT_DIR"
-    
+
     # Sync static assets with long cache
     info "Uploading static assets..."
-    aws s3 sync ./out $S3_BUCKET \
+    aws s3 sync ./out "$S3_BUCKET" \
         --delete \
         --cache-control "max-age=31536000,public" \
         --exclude "*.html" \
@@ -137,17 +153,17 @@ deploy_to_s3() {
         --exclude "*.txt" \
         --exclude "sw.js" \
         --exclude "manifest.json"
-    
+
     # Sync HTML files with no cache
     info "Uploading HTML files..."
-    aws s3 sync ./out $S3_BUCKET \
+    aws s3 sync ./out "$S3_BUCKET" \
         --delete \
         --cache-control "max-age=0,no-cache,no-store,must-revalidate" \
         --include "*.html"
-    
+
     # Sync other dynamic files with short cache
     info "Uploading dynamic files..."
-    aws s3 sync ./out $S3_BUCKET \
+    aws s3 sync ./out "$S3_BUCKET" \
         --delete \
         --cache-control "max-age=300,public" \
         --include "*.json" \
@@ -156,39 +172,40 @@ deploy_to_s3() {
     # Ensure service worker and manifest are never cached
     if [ -f "out/sw.js" ]; then
         info "Uploading service worker with no-cache..."
-        aws s3 cp ./out/sw.js $S3_BUCKET/sw.js \
+        aws s3 cp ./out/sw.js "$S3_BUCKET/sw.js" \
             --cache-control "max-age=0,no-cache,no-store,must-revalidate" \
             --content-type "application/javascript"
     fi
 
     if [ -f "out/manifest.json" ]; then
         info "Uploading manifest with short/no-cache..."
-        aws s3 cp ./out/manifest.json $S3_BUCKET/manifest.json \
+        aws s3 cp ./out/manifest.json "$S3_BUCKET/manifest.json" \
             --cache-control "max-age=0,no-cache,must-revalidate" \
             --content-type "application/manifest+json"
     fi
-    
+
     info "✓ S3 deployment completed"
 }
 
 # Invalidate CloudFront cache
 invalidate_cloudfront() {
     log "Invalidating CloudFront cache ($CLOUDFRONT_DISTRIBUTION_ID)..."
-    
-    INVALIDATION_ID=$(aws cloudfront create-invalidation \
-        --distribution-id $CLOUDFRONT_DISTRIBUTION_ID \
+
+    local invalidation_id
+    invalidation_id="$(aws cloudfront create-invalidation \
+        --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
         --paths "/*" \
         --query 'Invalidation.Id' \
-        --output text)
-    
-    info "✓ CloudFront invalidation created: $INVALIDATION_ID"
-    
+        --output text)"
+
+    info "✓ CloudFront invalidation created: $invalidation_id"
+
     # Wait for invalidation to complete (optional)
     if [ "$WAIT_FOR_INVALIDATION" = "true" ]; then
         info "Waiting for invalidation to complete..."
         aws cloudfront wait invalidation-completed \
-            --distribution-id $CLOUDFRONT_DISTRIBUTION_ID \
-            --id $INVALIDATION_ID
+            --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
+            --id "$invalidation_id"
         info "✓ Invalidation completed"
     else
         warn "Invalidation is in progress. It may take 5-15 minutes to complete."
@@ -268,51 +285,54 @@ EOF
 # Verify deployment
 verify_deployment() {
     log "Verifying deployment for $ENV_NAME..."
-    
+
     # Wait a moment for changes to propagate
     sleep 5
-    
+
     # Check if site is accessible
-    HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" $DOMAIN)
-    
-    if [ "$HTTP_STATUS" = "200" ]; then
+    local http_status
+    http_status="$(curl -s -o /dev/null -w "%{http_code}" "$DOMAIN")"
+
+    if [ "$http_status" = "200" ]; then
         info "✓ Site is accessible at $DOMAIN"
     else
-        warn "Site returned HTTP status: $HTTP_STATUS"
+        warn "Site returned HTTP status: $http_status"
         warn "This might be due to CloudFront cache. Try again in a few minutes."
     fi
-    
+
     # Check for specific content
-    if curl -s $DOMAIN | grep -q "Cascade"; then
+    if curl -s "$DOMAIN" | grep -q "Cascade"; then
         info "✓ Application content verified"
     else
         warn "Could not verify application content"
     fi
-    
+
     # Test security headers
     test_security_headers
 }
 
 # Deploy to all environments
 deploy_all() {
-    local environments=$(jq -r '.environments | keys[]' "$CONFIG_FILE")
-    
+    local environments
+    environments="$(jq -r '.environments | keys[]' "$CONFIG_FILE")"
+
     info "Deploying to all environments..."
     build_app
-    
-    for env in $environments; do
+
+    while IFS= read -r env; do
+        [ -z "$env" ] && continue
         echo
         log "========================================="
         log "Deploying to environment: $env"
         log "========================================="
-        
+
         load_config "$env"
         deploy_to_s3
         invalidate_cloudfront
         verify_deployment
-        
+
         log "✓ Deployment to $env ($ENV_NAME) completed"
-    done
+    done <<< "$environments"
 }
 
 # Show usage information

--- a/scripts/update-security-headers.sh
+++ b/scripts/update-security-headers.sh
@@ -49,8 +49,6 @@ build_csp() {
     fi
     csp="${csp:+$csp; }$directive"
   done < <(jq -r '.csp.requiredDirectives[]' "$BASELINE_FILE")
-  # Add upgrade-insecure-requests as a hardening measure
-  csp="$csp; upgrade-insecure-requests"
   echo "$csp"
 }
 
@@ -108,11 +106,12 @@ for POLICY_ID in $POLICY_IDS; do
       "IncludeSubdomains": true,
       "Preload": false
     }
-    # Set X-XSS-Protection (deprecated but required by CloudFront API)
+    # X-XSS-Protection is deprecated and can introduce its own XSS in legacy
+    # browsers (Edge Legacy, IE). OWASP recommends sending "X-XSS-Protection: 0"
+    # for sites with a strong CSP, which is what `Protection: false` sends.
     | .SecurityHeadersConfig.XSSProtection = {
       "Override": true,
-      "Protection": true,
-      "ModeBlock": true
+      "Protection": false
     }
     '
   )"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -89,8 +89,10 @@ export const metadata: Metadata = {
 export const viewport = {
   width: "device-width",
   initialScale: 1,
-  maximumScale: 1,
-  userScalable: false, // Prevent zoom on iOS for better touch UX
+  // Intentionally do NOT set maximumScale or userScalable: pinch-to-zoom is
+  // an accessibility requirement (WCAG 2.2 SC 1.4.4 Resize Text) and the iOS
+  // input-zoom annoyance is already handled by setting `font-size: 16px` on
+  // the relevant inputs in globals.css.
   shrinkToFit: "no", // Prevent iOS Safari from shrinking viewport
   viewportFit: "cover", // For iOS notch handling
   themeColor: [

--- a/src/lib/utils/security.ts
+++ b/src/lib/utils/security.ts
@@ -28,7 +28,21 @@ const ALLOWED_PATTERNS = {
 } as const;
 
 /**
- * Removes dangerous protocols and event handlers from input
+ * Defence-in-depth: strip a few known-dangerous substrings before storing
+ * user-controlled text in IndexedDB.
+ *
+ * **The actual XSS defence** for this app is React's automatic escaping of
+ * any value rendered as a child or attribute (we never use
+ * `dangerouslySetInnerHTML`; this is enforced by the `react/no-danger`
+ * ESLint rule), backed by the `Content-Security-Policy` response header
+ * (see `docs/security-headers-baseline.json`).
+ *
+ * This blacklist is intentionally lightweight — it makes a stored payload
+ * harder to misuse if it ever escapes React (e.g., copied into an
+ * `innerHTML` sink in a downstream tool, or rendered in a non-React export
+ * pipeline). Do NOT treat it as sufficient for any new context. New sinks
+ * MUST go through proper context-aware encoding (DOMPurify for HTML, JSON
+ * encoding for `<script>` data, etc.) instead of relying on this function.
  */
 function removeDangerousContent(input: string): string {
   return input

--- a/src/lib/utils/shareTask.ts
+++ b/src/lib/utils/shareTask.ts
@@ -106,28 +106,26 @@ export function generateTaskMailtoLink(task: Task, recipientEmail?: string): str
 }
 
 /**
- * Copy text to clipboard with fallback
+ * Copy text to the clipboard via the async Clipboard API.
+ *
+ * The previous implementation included a `document.execCommand('copy')`
+ * fallback for non-secure contexts and old browsers, but `execCommand` is
+ * deprecated, requires injecting a hidden DOM node, and is unavailable in
+ * every browser our `package.json` browserslist targets — Cascade is also
+ * served exclusively over HTTPS, so the fallback path was unreachable in
+ * practice. Removing it eliminates dead code and drops a vector that
+ * static analysers regularly flag.
  */
 export async function copyToClipboard(text: string): Promise<boolean> {
+  if (!navigator.clipboard || !window.isSecureContext) {
+    logger.error(
+      'Clipboard API unavailable. Cascade requires a secure (https://) context.'
+    );
+    return false;
+  }
   try {
-    if (navigator.clipboard && window.isSecureContext) {
-      await navigator.clipboard.writeText(text);
-      return true;
-    } else {
-      // Fallback for older browsers or non-HTTPS
-      const textArea = document.createElement('textarea');
-      textArea.value = text;
-      textArea.style.position = 'fixed';
-      textArea.style.left = '-999999px';
-      textArea.style.top = '-999999px';
-      document.body.appendChild(textArea);
-      textArea.focus();
-      textArea.select();
-      
-      const result = document.execCommand('copy');
-      document.body.removeChild(textArea);
-      return result;
-    }
+    await navigator.clipboard.writeText(text);
+    return true;
   } catch (error) {
     logger.error('Failed to copy to clipboard:', error);
     return false;

--- a/src/lib/utils/validation.ts
+++ b/src/lib/utils/validation.ts
@@ -107,8 +107,8 @@ function validateStringSchema(
   if (schema.maxLength && data.length > schema.maxLength) {
     warnings.push({ path, message: `String too long. Maximum: ${schema.maxLength}`, value: data.length, suggestion: 'Will be truncated' });
   }
-  if (schema.pattern && !new RegExp(schema.pattern).test(data)) {
-    errors.push({ path, message: `String does not match pattern: ${schema.pattern}`, value: data, severity: 'error' });
+  if (schema.pattern && !schema.pattern.test(data)) {
+    errors.push({ path, message: `String does not match pattern: ${schema.pattern.source}`, value: data, severity: 'error' });
   }
   if (schema.enum && !schema.enum.includes(data)) {
     errors.push({ path, message: `Invalid value. Must be: ${schema.enum.join(', ')}`, value: data, severity: 'error' });

--- a/src/lib/utils/validationSchemas.ts
+++ b/src/lib/utils/validationSchemas.ts
@@ -16,7 +16,12 @@ export interface ValidationSchema {
   maxItems?: number;
   minLength?: number;
   maxLength?: number;
-  pattern?: string;
+  /**
+   * Pre-compiled regular expression. Compiled once at module load instead of
+   * on every `validateSchema(...)` call so importing a large export.json
+   * doesn't pay the parse cost per item.
+   */
+  pattern?: RegExp;
   enum?: unknown[];
   format?: string;
   minimum?: number;
@@ -84,7 +89,7 @@ export const boardSchema: ValidationSchema = {
     id: { type: 'string', minLength: 1 },
     name: { type: 'string', minLength: 1, maxLength: 100 },
     description: { type: ['string', 'undefined'], maxLength: 500 },
-    color: { type: 'string', pattern: '^#[0-9A-Fa-f]{6}$' },
+    color: { type: 'string', pattern: /^#[0-9A-Fa-f]{6}$/ },
     isDefault: { type: 'boolean' },
     order: { type: 'number', minimum: 0 },
     createdAt: { type: 'string', format: 'date-time' },
@@ -133,7 +138,7 @@ export const settingsSchema: ValidationSchema = {
 export const exportDataSchema: ValidationSchema = {
   type: 'object',
   properties: {
-    version: { type: 'string', pattern: '^\\d+\\.\\d+\\.\\d+$' },
+    version: { type: 'string', pattern: /^\d+\.\d+\.\d+$/ },
     exportedAt: { type: 'string', format: 'date-time' },
     tasks: { type: 'array', items: taskSchema },
     boards: { type: 'array', items: boardSchema },


### PR DESCRIPTION
## Summary

Implements 13 of the 15 recommendations from the recent security review. Changes are organised in one commit by area:

**Self-hosted Docker (#3, #2, #6)**
- `Dockerfile`: install deps via Bun (`--frozen-lockfile --ignore-scripts`) instead of `npm ci` + a `package-lock.json` that doesn't exist in the repo. `--ignore-scripts` blocks postinstall scripts from a compromised transitive dep.
- New `docker/security-headers.conf`, `include`d from each `location` block in `docker/nginx.conf`, so Docker self-hosters get the same CSP / HSTS / X-Frame-Options / X-Content-Type-Options / Referrer-Policy / Permissions-Policy as the CloudFront-served sites. (`add_header` doesn't inherit into nested locations that define their own, hence the snippet.)
- `server_tokens off;` so nginx stops leaking its version.

**CSP baseline (#1, #9, #10, #8)**
- `docs/security-headers-baseline.json`: add `worker-src 'self'` (PWA registers `/sw.js`) and `upgrade-insecure-requests`. Document in a `_notes` array why `script-src`/`style-src` still need `'unsafe-inline'` (Next.js App Router static export emits inline `<script>` for next-themes anti-FOUC, RSC payload hydration, and the error page — tightening requires a per-page hash pipeline; left as a follow-up).
- `scripts/update-security-headers.sh`: stop appending `upgrade-insecure-requests` manually (now in the baseline) and switch `XSSProtection` to `Override:true / Protection:false`, which sends `X-XSS-Protection: 0` per OWASP guidance for sites with a strong CSP.

**App hardening (#4, #5, #7, #11, #14)**
- `src/lib/utils/security.ts`: re-document `removeDangerousContent` as defence-in-depth only and call out that React's auto-escaping is the actual XSS defence.
- `eslint.config.mjs`: add `"react/no-danger": "error"` to enforce no `dangerouslySetInnerHTML`.
- `package.json` overrides: pin `postcss` to `^8.4.49` to take the GHSA-qx2v-qp2m-jg93 patch (clears the moderate finding from `bun audit`).
- `src/app/layout.tsx`: drop `maximumScale: 1` / `userScalable: false` from viewport metadata (WCAG 2.2 SC 1.4.4 — Resize Text). The iOS input-zoom annoyance is already handled by `font-size: 16px` on inputs in `globals.css`.
- `src/lib/utils/validationSchemas.ts` + `validation.ts`: pre-compile `schema.pattern` as `RegExp` (was `string`, recompiled per call) so importing a large export.json doesn't pay the parse cost per item. Type changed from `string` to `RegExp`.
- `src/lib/utils/shareTask.ts`: drop the dead `document.execCommand('copy')` fallback path (the app is HTTPS-only, so it was unreachable).

**Operations (#12)**
- `scripts/deploy-multi.sh`: `set -euo pipefail`; default `WAIT_FOR_INVALIDATION`; validate `env_name` against `[A-Za-z0-9_-]+` before interpolating into `jq`; switch to `jq --arg`; quote all `$S3_BUCKET` / `$CLOUDFRONT_DISTRIBUTION_ID` / `$DOMAIN` expansions; use `read -r` and a heredoc loop instead of word-splitting `jq` output.

## Not in this PR
- **#13 (gate `.github/workflows/claude.yml` on `author_association`)** — Devin's git token lacks the `workflow` OAuth scope. The diff is saved at `/home/ubuntu/claude-yml-author-association-gate.patch` and is also reproduced in the chat. Apply with `git am` or paste manually before merging.
- **#15 (move committed planning markdown out of the public repo)** — left for you; it's a destructive housekeeping decision.

## Review & Testing Checklist for Human

- [ ] **Build the Docker image and run it.** `docker build .` was not exercised in this session, so the new bun-based builder + the `add_header ... always` + `include` pattern in nginx are unverified end-to-end. Suggested smoke test: `docker build -t cascade-local . && docker run --rm -p 8080:8080 cascade-local`, then `curl -I http://localhost:8080/` and confirm CSP / HSTS / X-Frame-Options / Permissions-Policy are present and the page still renders.
- [ ] **Plan the CloudFront rollout.** The baseline now requires `worker-src 'self'`, which the live policy doesn't have, so `bun run security:headers:check` against todos.vinny.dev / cascade.vinny.dev fails until you run `bun run security:headers:update`. Decide whether you want to land this PR first (CI baseline check stays green; live test fails until the script runs) or run the script first.
- [ ] **Verify pinch-to-zoom is acceptable.** Removing `userScalable: false` is a deliberate behaviour change on mobile.
- [ ] **Sanity check the validator change.** `schema.pattern` is now `RegExp` (was `string`). Tests (409/409) still pass and grep showed only one consumer, but worth a glance if any external fixtures pass string patterns.
- [ ] **Verify `react/no-danger` doesn't break local IDE lint.** The build's `bun run lint` shows the same 4 errors / 1 warning as `main` (all pre-existing, none from this PR), but if you have an editor integration it'll start flagging any future `dangerouslySetInnerHTML`.

### Notes
- Verified locally: `bunx tsc --noEmit` clean, `bun run test` 409/409 pass, `bun run build` succeeds, `bash -n` clean on both shell scripts. `bun run lint` produces the same 4 pre-existing errors (in `BoardItem.tsx`, `date-time-picker.tsx`, `boardHelpers.ts`) on this branch and on `main`, so this PR doesn't add lint debt.
- Per the security review, the live deployments (`https://todos.vinny.dev`, `https://cascade.vinny.dev`) still pass every check that was passing before; this PR only adds new requirements that need a CloudFront update to satisfy.
- The patch for the `claude.yml` gate is reproduced below for convenience:
  ```yaml
  if: |
    (
      github.event.sender.login == github.repository_owner ||
      github.event.issue.author_association == 'OWNER' ||
      github.event.issue.author_association == 'MEMBER' ||
      github.event.issue.author_association == 'COLLABORATOR' ||
      github.event.comment.author_association == 'OWNER' ||
      github.event.comment.author_association == 'MEMBER' ||
      github.event.comment.author_association == 'COLLABORATOR' ||
      github.event.review.author_association == 'OWNER' ||
      github.event.review.author_association == 'MEMBER' ||
      github.event.review.author_association == 'COLLABORATOR'
    ) && (
      ...existing @claude triggers...
    )
  ```

Link to Devin session: https://app.devin.ai/sessions/cfc6d41cad3a4cc3a777b3669de992a8
Requested by: @vscarpenter
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/kanban-todos/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->