### PR TITLE
fix(sonar): correct project key after repo rename

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectKey=vscarpenter_gsd-task-manager
+sonar.projectKey=vscarpenter_kanban-todos
 sonar.organization=vscarpenter
 sonar.projectName=Kanban Task Management
 


### PR DESCRIPTION
## Summary
- Update `sonar.projectKey` from `vscarpenter_gsd-task-manager` (old repo name) to `vscarpenter_kanban-todos` so local `sonar-scanner` runs and any future CI integration target the correct SonarCloud project.
- Merging this push to `main` will also trigger a fresh **Automatic Analysis** on SonarCloud (which is the original reason this came up — wanted to re-scan the repo).

## Test plan
- [ ] Merge to `main`
- [ ] Watch https://sonarcloud.io/project/activity?id=vscarpenter_kanban-todos for a new analysis row within ~1-2 min of merge
- [ ] Confirm quality gate result on https://sonarcloud.io/project/overview?id=vscarpenter_kanban-todos