### PR TITLE
fix(test): resolve TypeScript compilation errors in CI tests

### DIFF
--- a/src/lib/stores/__tests__/taskStore.filters.test.ts
+++ b/src/lib/stores/__tests__/taskStore.filters.test.ts
@@ -38,16 +38,16 @@ vi.mock('@/lib/utils/logger', () => ({
   },
 }))
 
-const mockSearchTasks = searchTasks as vi.Mock
-const mockSanitizeSearchQuery = sanitizeSearchQuery as vi.Mock
+const mockSearchTasks = searchTasks as any
+const mockSanitizeSearchQuery = sanitizeSearchQuery as any
 
 describe('taskStore.filters', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(mockSearchTasks).mockImplementation((tasks, query) => 
-      tasks.filter(task => task.title.toLowerCase().includes(query.toLowerCase()))
+    vi.mocked(mockSearchTasks).mockImplementation((tasks: Task[], query: string) => 
+      tasks.filter((task: Task) => task.title.toLowerCase().includes(query.toLowerCase()))
     )
-    vi.mocked(mockSanitizeSearchQuery).mockImplementation((query) => query.trim())
+    vi.mocked(mockSanitizeSearchQuery).mockImplementation((query: string) => query.trim())
   })
 
   const sampleTasks: Task[] = [

--- a/src/lib/stores/__tests__/taskStore.import.test.ts
+++ b/src/lib/stores/__tests__/taskStore.import.test.ts
@@ -20,7 +20,7 @@ const mockTaskDB = {
   updateTask: vi.fn().mockResolvedValue(undefined),
 }
 
-const mockExportTasksUtil = exportTasksUtil as vi.Mock
+const mockExportTasksUtil = exportTasksUtil as any
 
 describe('taskStore.import', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- Fix TypeScript errors in test files that were causing CI failures
- Add explicit type annotations to mock function parameters  
- Replace `vi.Mock` type assertions with `any` to avoid namespace errors during `tsc`

The `vi` namespace is only available in Vitest context, not during direct TypeScript compilation runs.

#### Test plan
- [x] TypeScript compilation passes: `bun run tsc --noEmit`
- [x] All tests still pass: `bun run test`
- [x] No functionality lost in test coverage

Generated with [Devin](https://cli.devin.ai/docs)