### PR TITLE
fix: cascade task deletion when a board is deleted

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,29 @@
+# Kanban Todos
+
+A privacy-first, client-side Kanban todo app. All data lives in the user's browser (IndexedDB); nothing is sent to a server. This file captures the domain language the codebase should speak consistently.
+
+## Language
+
+**Board**:
+A column-bearing workspace that owns a set of tasks. One board is the default board and cannot be deleted.
+_Avoid_: list, project, workspace
+
+**Task**:
+A unit of work belonging to exactly one board, with a status (`todo` / `in-progress` / `done`) and an optional archive flag.
+_Avoid_: todo, item, card
+
+**Board ownership**:
+A board owns its tasks. Deleting a board **cascades** to its tasks — board and tasks are removed together, atomically, so tasks never outlive their board.
+
+**Orphaned task**:
+A task whose `boardId` points at a board that no longer exists. This is always a bug, never a valid state; the cascade in **Board ownership** exists to prevent it.
+
+**Cascade**:
+The removal of a board together with every task it owns, in a single IndexedDB transaction. Either both go or neither does.
+
+## Example dialogue
+
+> **Dev:** When someone deletes a board, what happens to the tasks on it?
+> **Domain expert:** They go too. A board *owns* its tasks — deleting the board cascades to them.
+> **Dev:** So a task could never sit around pointing at a board that's gone?
+> **Domain expert:** Right. That'd be an *orphaned task*, and that's a bug. The cascade is one atomic step precisely so it can't happen.

--- a/src/components/BoardDeleteDialog.tsx
+++ b/src/components/BoardDeleteDialog.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AlertTriangle, Trash2 } from "lucide-react";
+import { toast } from "sonner";
 import { useBoardStore } from "@/lib/stores/boardStore";
 import { useTaskStore } from "@/lib/stores/taskStore";
 import { Board } from "@/lib/types";
@@ -37,6 +38,7 @@ export function BoardDeleteDialog({ open, onOpenChange, board }: BoardDeleteDial
     
     try {
       await deleteBoard(board.id);
+      toast.success('Board deleted');
       onOpenChange(false);
       setConfirmationText("");
     } catch (error) {

--- a/src/components/CrossBoardNavigationHandler.tsx
+++ b/src/components/CrossBoardNavigationHandler.tsx
@@ -109,24 +109,6 @@ export function CrossBoardNavigationHandler({ children }: CrossBoardNavigationHa
     };
   }, [boards, handleCrossBoardNavigation]);
 
-  // Listen for board deletion events to clean up tasks
-  useEffect(() => {
-    const handleBoardDeletion = (event: CustomEvent<{ boardId: string }>) => {
-      const { handleBoardDeletion } = useTaskStore.getState();
-      handleBoardDeletion(event.detail.boardId);
-      
-      toast.info("Board deleted", {
-        description: "Tasks from that board are no longer in search results.",
-      });
-    };
-
-    window.addEventListener('board-deleted', handleBoardDeletion as EventListener);
-    
-    return () => {
-      window.removeEventListener('board-deleted', handleBoardDeletion as EventListener);
-    };
-  }, []);
-
   return <>{children}</>;
 }
 
@@ -134,14 +116,6 @@ export function CrossBoardNavigationHandler({ children }: CrossBoardNavigationHa
 export const triggerCrossBoardNavigation = (taskId: string) => {
   const event = new CustomEvent('navigate-to-task-board', {
     detail: { taskId }
-  });
-  window.dispatchEvent(event);
-};
-
-// Utility function to notify about board deletion
-export const notifyBoardDeletion = (boardId: string) => {
-  const event = new CustomEvent('board-deleted', {
-    detail: { boardId }
   });
   window.dispatchEvent(event);
 };

--- a/src/components/__tests__/CriticalDialogs.test.tsx
+++ b/src/components/__tests__/CriticalDialogs.test.tsx
@@ -229,6 +229,25 @@ describe('critical dialog flows', () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it('confirms a successful board deletion with a toast', async () => {
+    render(
+      <BoardDeleteDialog
+        open
+        onOpenChange={vi.fn()}
+        board={makeBoard({ id: 'board-3', name: 'Client Work' })}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/type .* to confirm deletion/i), {
+      target: { value: 'Client Work' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^delete board$/i }));
+
+    await waitFor(() => {
+      expect(mocks.toastSuccess).toHaveBeenCalledWith('Board deleted');
+    });
+  });
+
   it('uses an explicit confirmation step before moving a task to the default board', async () => {
     const onOpenChange = vi.fn();
 

--- a/src/lib/stores/__tests__/boardStore.test.ts
+++ b/src/lib/stores/__tests__/boardStore.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Task } from '@/lib/types';
 import { useBoardStore } from '../boardStore';
 
 // Mock the database
@@ -374,6 +375,27 @@ describe('boardStore', () => {
       await deleteBoard('board-2');
 
       expect(taskDB.deleteBoard).toHaveBeenCalledWith('board-2');
+    });
+
+    it('prunes the deleted board\'s tasks from the task store', async () => {
+      const { useTaskStore } = await import('../taskStore');
+      useTaskStore.setState({
+        tasks: [
+          { id: 'task-on-deleted', boardId: 'board-2' },
+          { id: 'task-kept', boardId: 'board-1' },
+        ] as unknown as Task[],
+        filteredTasks: [
+          { id: 'task-on-deleted', boardId: 'board-2' },
+          { id: 'task-kept', boardId: 'board-1' },
+        ] as unknown as Task[],
+      });
+
+      const { deleteBoard } = useBoardStore.getState();
+      await deleteBoard('board-2');
+
+      const { tasks, filteredTasks } = useTaskStore.getState();
+      expect(tasks.map(t => t.id)).toEqual(['task-kept']);
+      expect(filteredTasks.map(t => t.id)).toEqual(['task-kept']);
     });
 
     it('prevents deleting the default board', async () => {

--- a/src/lib/stores/__tests__/taskStore.test.ts
+++ b/src/lib/stores/__tests__/taskStore.test.ts
@@ -547,7 +547,7 @@ describe('taskStore', () => {
         },
       });
 
-      useTaskStore.getState().handleBoardDeletion('board-deleted');
+      useTaskStore.getState().removeTasksForBoard('board-deleted');
 
       const { tasks, filteredTasks, filters, error } = useTaskStore.getState();
       expect(tasks.map(task => task.id)).toEqual(['kept-task']);

--- a/src/lib/stores/boardStore.ts
+++ b/src/lib/stores/boardStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { Board } from '@/lib/types';
 import { taskDB } from '@/lib/utils/database';
+import { useTaskStore } from './taskStore';
 import { ExportData } from '@/lib/utils/exportImport';
 import { sanitizeBoardData } from '@/lib/utils/security';
 import { logger } from '@/lib/utils/logger';
@@ -226,8 +227,11 @@ export const useBoardStore = create<BoardState & BoardActions>((set, get) => ({
               throw new Error('Cannot delete the default board');
             }
 
+            // The board and its tasks are gone from storage; now prune the
+            // deleted board's tasks from the task store's in-memory state.
             await taskDB.deleteBoard(boardId);
-            
+            useTaskStore.getState().removeTasksForBoard(boardId);
+
             set((state) => {
               const newBoards = state.boards.filter(b => b.id !== boardId);
               let newCurrentBoardId = state.currentBoardId;

--- a/src/lib/stores/taskStore.ts
+++ b/src/lib/stores/taskStore.ts
@@ -96,7 +96,7 @@ interface TaskActions {
 
   // Validation
   validateBoardAccess: (boardId: string) => Promise<boolean>;
-  handleBoardDeletion: (deletedBoardId: string) => void;
+  removeTasksForBoard: (deletedBoardId: string) => void;
   recoverFromSearchError: () => void;
   validateTaskIntegrity: (task: Task) => boolean;
 
@@ -147,7 +147,7 @@ function createValidateBoardAccess() {
   };
 }
 
-function createHandleBoardDeletion(get: () => TaskState, set: (state: Partial<TaskState>) => void) {
+function createRemoveTasksForBoard(get: () => TaskState, set: (state: Partial<TaskState>) => void) {
   return (deletedBoardId: string) => {
     const { tasks, filters, filteredTasks } = get();
 
@@ -270,7 +270,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
 
       // Validation operations
       validateBoardAccess: createValidateBoardAccess(),
-      handleBoardDeletion: createHandleBoardDeletion(get, set),
+      removeTasksForBoard: createRemoveTasksForBoard(get, set),
       recoverFromSearchError: createRecoverFromSearchError(get, set),
       validateTaskIntegrity,
       initializeStore: createInitializeStore(get, set),

--- a/src/lib/utils/__tests__/database.test.ts
+++ b/src/lib/utils/__tests__/database.test.ts
@@ -158,6 +158,22 @@ describe('TaskDatabase', () => {
       expect(boards).toHaveLength(1);
       expect(boards[0].id).toBe('board-2');
     });
+
+    it('cascades to the board tasks, leaving other boards untouched', async () => {
+      await db.addBoard(createTestBoard({ id: 'board-1' }));
+      await db.addBoard(createTestBoard({ id: 'board-2' }));
+      await db.addTask(createTestTask({ id: 'task-1', boardId: 'board-1' }));
+      await db.addTask(createTestTask({ id: 'task-2', boardId: 'board-1', archivedAt: new Date() }));
+      await db.addTask(createTestTask({ id: 'task-3', boardId: 'board-2' }));
+
+      await db.deleteBoard('board-1');
+
+      const boards = await db.getBoards();
+      const tasks = await db.getTasks();
+      expect(boards.map(b => b.id)).toEqual(['board-2']);
+      // both the active and the archived task on board-1 are gone; no orphans
+      expect(tasks.map(t => t.id)).toEqual(['task-3']);
+    });
   });
 
   describe('settings operations', () => {

--- a/src/lib/utils/database.ts
+++ b/src/lib/utils/database.ts
@@ -165,13 +165,22 @@ export class TaskDatabase {
     const db = this.db;
     if (!db) throw new Error('Database not initialized');
 
+    // A board owns its tasks: delete the board and every task on it in one
+    // transaction so tasks can never outlive their board (no orphaned tasks).
     return new Promise((resolve, reject) => {
-      const transaction = db.transaction(['boards'], 'readwrite');
-      const store = transaction.objectStore('boards');
-      const request = store.delete(boardId);
+      const transaction = db.transaction(['tasks', 'boards'], 'readwrite');
+      transaction.onerror = () => reject(transaction.error);
+      transaction.oncomplete = () => resolve();
 
-      request.onerror = () => reject(request.error);
-      request.onsuccess = () => resolve();
+      const tasks = transaction.objectStore('tasks');
+      const taskKeysRequest = tasks.index('boardId').getAllKeys(boardId);
+      taskKeysRequest.onsuccess = () => {
+        for (const key of taskKeysRequest.result) {
+          tasks.delete(key);
+        }
+      };
+
+      transaction.objectStore('boards').delete(boardId);
     });
   }
 


### PR DESCRIPTION
## Summary

Deleting a board only removed the **board record** — its tasks were left **orphaned** in IndexedDB and in the in-memory task store. They survived reloads and leaked into all-boards search and exports. The one cleanup path (`taskStore.handleBoardDeletion`) was only reachable through a `board-deleted` DOM event that **nothing ever dispatched** (`notifyBoardDeletion` had zero callers).

This makes board deletion one deep, atomic operation — surfaced by the `/improve-codebase-architecture` review (candidate #1) and resolved through a grilling session on the seam, atomicity scope, and feedback.

## Changes

- **`database.ts`** — `deleteBoard` now deletes the board **and all its tasks** (active + archived) in a single `['tasks','boards']` transaction, via the existing `boardId` index (reuses the `importData` resolve-on-complete pattern). Tasks can no longer outlive their board.
- **`boardStore.deleteBoard`** — after the cascade succeeds, prunes the deleted board's tasks from the task store via a direct, one-directional `useTaskStore.getState().removeTasksForBoard(id)` call. `currentBoardId` repoint stays a separate settings write (already self-healing via `selectCurrentBoard`).
- **`taskStore`** — renamed `handleBoardDeletion` → **`removeTasksForBoard`**; the in-memory prune is now live code instead of dead-event plumbing.
- **`CrossBoardNavigationHandler`** — removed the dead `board-deleted` listener + `notifyBoardDeletion` (cross-board *navigation* event bits left untouched).
- **`BoardDeleteDialog`** — `toast.success('Board deleted')` on success (replaces the toast that was wired to the dead event).
- **`CONTEXT.md`** (new) — seeds the domain language this work crystallized: **Board ownership**, **Orphaned task**, **Cascade**.

## Why this design

- **Atomicity scope:** board + tasks atomic kills the orphan bug; settings repoint stays separate because a dangling `currentBoardId` is benign and already self-heals on load. Folding settings into the delete primitive would leak board-selection concern into it.
- **Coordination:** the DOM event bus was a fake seam (one dispatcher, one listener, never fired). A direct in-process call is the honest version — and `boardStore → taskStore` is a clean, new, one-directional dependency (no cycle).

## Tests (TDD, RED→GREEN)

- DB cascade deletes the board's tasks and leaves other boards' tasks intact (`database.test.ts`)
- Deleting a board prunes its tasks from the task store (`boardStore.test.ts`)
- Successful deletion fires a toast (`CriticalDialogs.test.tsx`)
- Existing in-memory prune test updated to the renamed symbol (`taskStore.test.ts`)

## Verification

- ✅ Full suite: **513 tests passing** (36 files)
- ✅ `tsc --noEmit` clean
- ✅ ESLint clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/kanban-todos/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->