### PR TITLE
refactor: single source of truth for task status/priority enums

### DIFF
--- a/src/components/DragDropProvider.tsx
+++ b/src/components/DragDropProvider.tsx
@@ -14,7 +14,7 @@ import {
   closestCenter,
   rectIntersection,
 } from "@dnd-kit/core";
-import { Task } from "@/lib/types";
+import { Task, TASK_STATUSES } from "@/lib/types";
 import { useTaskStore } from "@/lib/stores/taskStore";
 import { celebrateTaskCompletion } from "@/lib/utils/celebrateCompletion";
 import TaskCard from "./kanban/TaskCard";
@@ -77,7 +77,7 @@ export function DragDropProvider({
       const taskId = active.id as string;
       const newStatus = over.id as Task['status'];
 
-      if (newStatus && ['todo', 'in-progress', 'done'].includes(newStatus)) {
+      if (newStatus && TASK_STATUSES.includes(newStatus)) {
         // Celebrate only real transitions into 'done' (not done → done drops).
         const previousStatus = tasks.find((t: Task) => t.id === taskId)?.status;
         moveTask(taskId, newStatus);

--- a/src/components/board/CrossBoardGroups.tsx
+++ b/src/components/board/CrossBoardGroups.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Task, Board } from "@/lib/types";
+import { Task, Board, TASK_STATUSES } from "@/lib/types";
 
 interface BoardGroup {
   board: Board;
@@ -40,7 +40,7 @@ export function CrossBoardGroups({ boardGroups, onNavigateToBoard }: CrossBoardG
               </Button>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              {['todo', 'in-progress', 'done'].map((status) => {
+              {TASK_STATUSES.map((status) => {
                 const statusTasks = tasks.filter(t => t.status === status);
                 return (
                   <div key={status} className="space-y-2">

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,15 +1,23 @@
+// Single source of truth for task enum values. Runtime validators, schemas,
+// and the type system all derive from these — keep new values here only.
+export const TASK_STATUSES = ['todo', 'in-progress', 'done'] as const;
+export const TASK_PRIORITIES = ['low', 'medium', 'high'] as const;
+
+export type TaskStatus = (typeof TASK_STATUSES)[number];
+export type TaskPriority = (typeof TASK_PRIORITIES)[number];
+
 export interface Task {
   id: string;
   title: string;
   description?: string;
-  status: 'todo' | 'in-progress' | 'done';
+  status: TaskStatus;
   boardId: string;
   createdAt: Date;
   updatedAt: Date;
   completedAt?: Date;
   archivedAt?: Date;
   dueDate?: Date;
-  priority: 'low' | 'medium' | 'high';
+  priority: TaskPriority;
   tags: string[];
   progress?: number; // Progress percentage (0-100), only for 'in-progress' tasks
 }

--- a/src/lib/utils/__tests__/taskValidation.test.ts
+++ b/src/lib/utils/__tests__/taskValidation.test.ts
@@ -4,7 +4,8 @@ import {
   validateTaskCollection,
   isValidTask
 } from '../taskValidation';
-import { Task } from '@/lib/types';
+import { Task, TASK_STATUSES, TASK_PRIORITIES } from '@/lib/types';
+import { taskSchema } from '../validationSchemas';
 import { logger } from '@/lib/utils/logger';
 
 // Helper to create a valid test task
@@ -322,6 +323,16 @@ describe('taskValidation utility', () => {
 
       const result = validateTaskCollection(mixedTasks);
       expect(result).toHaveLength(90);
+    });
+  });
+
+  describe('single source of task enums', () => {
+    it('drives the schema status enum from the shared TASK_STATUSES constant', () => {
+      expect(taskSchema.properties?.status.enum).toEqual([...TASK_STATUSES]);
+    });
+
+    it('drives the schema priority enum from the shared TASK_PRIORITIES constant', () => {
+      expect(taskSchema.properties?.priority.enum).toEqual([...TASK_PRIORITIES]);
     });
   });
 });

--- a/src/lib/utils/taskValidation.ts
+++ b/src/lib/utils/taskValidation.ts
@@ -1,9 +1,5 @@
-import { Task } from '@/lib/types';
+import { Task, TASK_STATUSES, TASK_PRIORITIES } from '@/lib/types';
 import { logger } from '@/lib/utils/logger';
-
-// Valid enum values for task fields
-const VALID_STATUSES = ['todo', 'in-progress', 'done'] as const;
-const VALID_PRIORITIES = ['low', 'medium', 'high'] as const;
 
 /**
  * Validates that a task has all required string fields populated
@@ -56,21 +52,21 @@ function hasValidDataTypes(task: Task): boolean {
  */
 function hasValidEnumValues(task: Task): boolean {
   // Validate status
-  if (!VALID_STATUSES.includes(task.status)) {
+  if (!TASK_STATUSES.includes(task.status)) {
     logger.warn('Task has invalid status', {
       taskId: task.id,
       status: task.status,
-      validStatuses: VALID_STATUSES
+      validStatuses: TASK_STATUSES
     });
     return false;
   }
 
   // Validate priority (optional field)
-  if (task.priority && !VALID_PRIORITIES.includes(task.priority)) {
+  if (task.priority && !TASK_PRIORITIES.includes(task.priority)) {
     logger.warn('Task has invalid priority', {
       taskId: task.id,
       priority: task.priority,
-      validPriorities: VALID_PRIORITIES
+      validPriorities: TASK_PRIORITIES
     });
     return false;
   }

--- a/src/lib/utils/validationSchemas.ts
+++ b/src/lib/utils/validationSchemas.ts
@@ -3,6 +3,8 @@
  * Consumed by validation.ts for runtime validation and sanitization.
  */
 
+import { TASK_STATUSES, TASK_PRIORITIES } from '@/lib/types';
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -68,14 +70,14 @@ export const taskSchema: ValidationSchema = {
     id: { type: 'string', minLength: 1 },
     title: { type: 'string', minLength: 1, maxLength: 500 },
     description: { type: ['string', 'undefined'], maxLength: 2000 },
-    status: { type: 'string', enum: ['todo', 'in-progress', 'done'] },
+    status: { type: 'string', enum: [...TASK_STATUSES] },
     boardId: { type: 'string', minLength: 1 },
     createdAt: { type: 'string', format: 'date-time' },
     updatedAt: { type: 'string', format: 'date-time' },
     completedAt: { type: ['string', 'undefined'], format: 'date-time' },
     archivedAt: { type: ['string', 'undefined'], format: 'date-time' },
     dueDate: { type: ['string', 'undefined'], format: 'date-time' },
-    priority: { type: 'string', enum: ['low', 'medium', 'high'] },
+    priority: { type: 'string', enum: [...TASK_PRIORITIES] },
     tags: { type: 'array', items: { type: 'string', maxLength: 50 }, maxItems: 20 },
     progress: { type: ['number', 'undefined'], minimum: 0, maximum: 100 }
   },


### PR DESCRIPTION
Architecture review candidate **#6** (#1 already merged via #79).

## Summary

The task **status** and **priority** values were duplicated across **five** sites — any new status meant editing all of them, with drift a constant risk:

- `types/index.ts` — the TS union types
- `validationSchemas.ts:71,78` — the schema `enum`s
- `taskValidation.ts:5-6` — `VALID_STATUSES` / `VALID_PRIORITIES`
- `DragDropProvider.tsx:80` — drop-target validation literal
- `board/CrossBoardGroups.tsx:43` — the cross-board column renderer literal

## Change

- Define `TASK_STATUSES` / `TASK_PRIORITIES` **once** in `types/index.ts`; derive `TaskStatus` / `TaskPriority` from them (`(typeof TASK_STATUSES)[number]`).
- Point all five consumers at the shared constant.
- Add a regression test locking the schema enums to the shared constants so they can't drift again.

## Scope note

Does the **enum single-source** (the Strong core of candidate #6). The report's secondary ideas (collapsing the shallow `validateTask` wrappers, unifying the two sanitization passes) were left out — lower value, higher risk, better done when that code is next touched.

## Verification
- ✅ Full suite: **515 tests passing**
- ✅ `tsc --noEmit` clean
- ✅ ESLint clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/kanban-todos/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->