### PR TITLE
fix: route search-scope persistence through settingsStore (single owner)

### DIFF
--- a/src/components/DragDropProvider.tsx
+++ b/src/components/DragDropProvider.tsx
@@ -14,7 +14,7 @@ import {
   closestCenter,
   rectIntersection,
 } from "@dnd-kit/core";
-import { Task } from "@/lib/types";
+import { Task, TASK_STATUSES } from "@/lib/types";
 import { useTaskStore } from "@/lib/stores/taskStore";
 import { celebrateTaskCompletion } from "@/lib/utils/celebrateCompletion";
 import TaskCard from "./kanban/TaskCard";
@@ -77,7 +77,7 @@ export function DragDropProvider({
       const taskId = active.id as string;
       const newStatus = over.id as Task['status'];
 
-      if (newStatus && ['todo', 'in-progress', 'done'].includes(newStatus)) {
+      if (newStatus && TASK_STATUSES.includes(newStatus)) {
         // Celebrate only real transitions into 'done' (not done → done drops).
         const previousStatus = tasks.find((t: Task) => t.id === taskId)?.status;
         moveTask(taskId, newStatus);

--- a/src/components/board/CrossBoardGroups.tsx
+++ b/src/components/board/CrossBoardGroups.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Task, Board } from "@/lib/types";
+import { Task, Board, TASK_STATUSES } from "@/lib/types";
 
 interface BoardGroup {
   board: Board;
@@ -40,7 +40,7 @@ export function CrossBoardGroups({ boardGroups, onNavigateToBoard }: CrossBoardG
               </Button>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              {['todo', 'in-progress', 'done'].map((status) => {
+              {TASK_STATUSES.map((status) => {
                 const statusTasks = tasks.filter(t => t.status === status);
                 return (
                   <div key={status} className="space-y-2">

--- a/src/lib/stores/__tests__/taskStore.filters.test.ts
+++ b/src/lib/stores/__tests__/taskStore.filters.test.ts
@@ -1,10 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { 
+import {
   applyFiltersToTasks,
+  createSaveSearchScope,
 } from '../taskStore.filters'
 import { Task, TaskFilters } from '@/lib/types'
+import { useSettingsStore } from '@/lib/stores/settingsStore'
 import { sanitizeSearchQuery } from '@/lib/utils/security'
 import { searchTasks } from '@/lib/utils/taskSearch'
+
+vi.mock('@/lib/stores/settingsStore', () => ({
+  useSettingsStore: { getState: vi.fn() },
+}))
 
 // Mock dependencies
 vi.mock('@/lib/utils/security', () => ({
@@ -219,5 +225,31 @@ describe('taskStore.filters', () => {
     })
   })
 
-  
+  describe('createSaveSearchScope', () => {
+    const mockGetState = vi.mocked(useSettingsStore.getState)
+
+    function stubSettings(rememberScope: boolean, setDefaultSearchScope = vi.fn()) {
+      mockGetState.mockReturnValue({
+        settings: { searchPreferences: { rememberScope, defaultScope: 'current-board' } },
+        setDefaultSearchScope,
+      } as unknown as ReturnType<typeof useSettingsStore.getState>)
+      return setDefaultSearchScope
+    }
+
+    it('persists the scope through settingsStore when rememberScope is on', async () => {
+      const setDefaultSearchScope = stubSettings(true)
+
+      await createSaveSearchScope()('all-boards')
+
+      expect(setDefaultSearchScope).toHaveBeenCalledWith('all-boards')
+    })
+
+    it('does not persist when rememberScope is off', async () => {
+      const setDefaultSearchScope = stubSettings(false)
+
+      await createSaveSearchScope()('all-boards')
+
+      expect(setDefaultSearchScope).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/src/lib/stores/taskStore.filters.ts
+++ b/src/lib/stores/taskStore.filters.ts
@@ -5,6 +5,7 @@
 
 import { Task, TaskFilters, SearchScope } from '@/lib/types';
 import { taskDB } from '@/lib/utils/database';
+import { useSettingsStore } from '@/lib/stores/settingsStore';
 import { sanitizeSearchQuery, searchRateLimiter } from '@/lib/utils/security';
 import { searchTasks } from '@/lib/utils/taskSearch';
 import {
@@ -374,12 +375,12 @@ export function createLoadSearchPreferences(get: () => TaskStoreState, set: Stor
 export function createSaveSearchScope() {
   return async (scope: SearchScope) => {
     try {
-      const settings = await taskDB.getSettings();
-      if (settings?.searchPreferences?.rememberScope) {
-        await taskDB.updateSettings({
-          ...settings,
-          searchPreferences: { ...settings.searchPreferences, defaultScope: scope },
-        });
+      // settingsStore is the single owner of Settings: persist the scope
+      // through it (only when the user has opted to remember their scope)
+      // instead of writing to the database directly behind its back.
+      const { settings, setDefaultSearchScope } = useSettingsStore.getState();
+      if (settings.searchPreferences.rememberScope) {
+        await setDefaultSearchScope(scope);
       }
     } catch (error: unknown) {
       logger.warn('Failed to save search scope preference:', error);

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,15 +1,23 @@
+// Single source of truth for task enum values. Runtime validators, schemas,
+// and the type system all derive from these — keep new values here only.
+export const TASK_STATUSES = ['todo', 'in-progress', 'done'] as const;
+export const TASK_PRIORITIES = ['low', 'medium', 'high'] as const;
+
+export type TaskStatus = (typeof TASK_STATUSES)[number];
+export type TaskPriority = (typeof TASK_PRIORITIES)[number];
+
 export interface Task {
   id: string;
   title: string;
   description?: string;
-  status: 'todo' | 'in-progress' | 'done';
+  status: TaskStatus;
   boardId: string;
   createdAt: Date;
   updatedAt: Date;
   completedAt?: Date;
   archivedAt?: Date;
   dueDate?: Date;
-  priority: 'low' | 'medium' | 'high';
+  priority: TaskPriority;
   tags: string[];
   progress?: number; // Progress percentage (0-100), only for 'in-progress' tasks
 }

--- a/src/lib/utils/__tests__/taskValidation.test.ts
+++ b/src/lib/utils/__tests__/taskValidation.test.ts
@@ -4,7 +4,8 @@ import {
   validateTaskCollection,
   isValidTask
 } from '../taskValidation';
-import { Task } from '@/lib/types';
+import { Task, TASK_STATUSES, TASK_PRIORITIES } from '@/lib/types';
+import { taskSchema } from '../validationSchemas';
 import { logger } from '@/lib/utils/logger';
 
 // Helper to create a valid test task
@@ -322,6 +323,16 @@ describe('taskValidation utility', () => {
 
       const result = validateTaskCollection(mixedTasks);
       expect(result).toHaveLength(90);
+    });
+  });
+
+  describe('single source of task enums', () => {
+    it('drives the schema status enum from the shared TASK_STATUSES constant', () => {
+      expect(taskSchema.properties?.status.enum).toEqual([...TASK_STATUSES]);
+    });
+
+    it('drives the schema priority enum from the shared TASK_PRIORITIES constant', () => {
+      expect(taskSchema.properties?.priority.enum).toEqual([...TASK_PRIORITIES]);
     });
   });
 });

--- a/src/lib/utils/taskValidation.ts
+++ b/src/lib/utils/taskValidation.ts
@@ -1,9 +1,5 @@
-import { Task } from '@/lib/types';
+import { Task, TASK_STATUSES, TASK_PRIORITIES } from '@/lib/types';
 import { logger } from '@/lib/utils/logger';
-
-// Valid enum values for task fields
-const VALID_STATUSES = ['todo', 'in-progress', 'done'] as const;
-const VALID_PRIORITIES = ['low', 'medium', 'high'] as const;
 
 /**
  * Validates that a task has all required string fields populated
@@ -56,21 +52,21 @@ function hasValidDataTypes(task: Task): boolean {
  */
 function hasValidEnumValues(task: Task): boolean {
   // Validate status
-  if (!VALID_STATUSES.includes(task.status)) {
+  if (!TASK_STATUSES.includes(task.status)) {
     logger.warn('Task has invalid status', {
       taskId: task.id,
       status: task.status,
-      validStatuses: VALID_STATUSES
+      validStatuses: TASK_STATUSES
     });
     return false;
   }
 
   // Validate priority (optional field)
-  if (task.priority && !VALID_PRIORITIES.includes(task.priority)) {
+  if (task.priority && !TASK_PRIORITIES.includes(task.priority)) {
     logger.warn('Task has invalid priority', {
       taskId: task.id,
       priority: task.priority,
-      validPriorities: VALID_PRIORITIES
+      validPriorities: TASK_PRIORITIES
     });
     return false;
   }

--- a/src/lib/utils/validationSchemas.ts
+++ b/src/lib/utils/validationSchemas.ts
@@ -3,6 +3,8 @@
  * Consumed by validation.ts for runtime validation and sanitization.
  */
 
+import { TASK_STATUSES, TASK_PRIORITIES } from '@/lib/types';
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -68,14 +70,14 @@ export const taskSchema: ValidationSchema = {
     id: { type: 'string', minLength: 1 },
     title: { type: 'string', minLength: 1, maxLength: 500 },
     description: { type: ['string', 'undefined'], maxLength: 2000 },
-    status: { type: 'string', enum: ['todo', 'in-progress', 'done'] },
+    status: { type: 'string', enum: [...TASK_STATUSES] },
     boardId: { type: 'string', minLength: 1 },
     createdAt: { type: 'string', format: 'date-time' },
     updatedAt: { type: 'string', format: 'date-time' },
     completedAt: { type: ['string', 'undefined'], format: 'date-time' },
     archivedAt: { type: ['string', 'undefined'], format: 'date-time' },
     dueDate: { type: ['string', 'undefined'], format: 'date-time' },
-    priority: { type: 'string', enum: ['low', 'medium', 'high'] },
+    priority: { type: 'string', enum: [...TASK_PRIORITIES] },
     tags: { type: 'array', items: { type: 'string', maxLength: 50 }, maxItems: 20 },
     progress: { type: ['number', 'undefined'], minimum: 0, maximum: 100 }
   },


### PR DESCRIPTION
Architecture review candidate **#2**. **Stacked on #80** (candidate #6) — base will retarget to `main` once #80 merges.

## Problem

`taskStore.filters.createSaveSearchScope` wrote the search-scope preference **straight to `taskDB`** (`getSettings` → merge → `updateSettings`), bypassing `settingsStore` — the actual owner of `Settings`. `settingsStore.setDefaultSearchScope` existed but had **zero callers**. Two writers of the same record = stale-write risk: the direct path re-read settings from disk and could clobber an in-memory `settingsStore` change.

## Change

- `createSaveSearchScope` now calls `settingsStore.setDefaultSearchScope(scope)` — `settingsStore` becomes the single writer.
- Preserves the existing semantics: only persist when `searchPreferences.rememberScope` is on (gated before the call).
- One-directional dependency (`taskStore.filters → settingsStore`); no cycle.

## Scope note

The load path (`createLoadSearchPreferences`) still reads from `taskDB` on init — that's a read, not a competing write, and routing it through `settingsStore` would introduce store-init-ordering risk. Left as-is deliberately.

## Tests (TDD)

- Persists the scope through `settingsStore` when `rememberScope` is on
- Does **not** persist when `rememberScope` is off

## Verification
- ✅ Full suite: **517 tests passing**
- ✅ `tsc --noEmit` clean
- ✅ ESLint clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/kanban-todos/pull/81" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->