### PR TITLE
refactor: read the import file once, not twice

### DIFF
--- a/src/components/ImportDialog.tsx
+++ b/src/components/ImportDialog.tsx
@@ -4,7 +4,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } f
 import { useTaskStore } from "@/lib/stores/taskStore";
 import { useBoardStore } from "@/lib/stores/boardStore";
 import { useSettingsStore } from "@/lib/stores/settingsStore";
-import { readJsonFile, previewImportData } from "@/lib/utils/fileHandling";
+import { previewImportData } from "@/lib/utils/fileHandling";
 import { processAdvancedImport, detectImportConflicts } from "@/lib/utils/exportImport";
 import { useImportState, ImportPreview } from "@/hooks/useImportState";
 import { FileSelectStep } from "./import/FileSelectStep";
@@ -72,9 +72,10 @@ export function ImportDialog({ open, onOpenChange }: ImportDialogProps) {
         fileSize: result.preview.fileSize,
       };
 
-      const fileReadResult = await readJsonFile(file);
-      if (fileReadResult.success && fileReadResult.data) {
-        state.setImportData(fileReadResult.data);
+      // previewImportData already parsed the file — reuse its data instead of
+      // reading and parsing the same (potentially large) file a second time.
+      if (result.data) {
+        state.setImportData(result.data);
       }
 
       state.setImportPreview(importPreview);

--- a/src/components/__tests__/CriticalDialogs.test.tsx
+++ b/src/components/__tests__/CriticalDialogs.test.tsx
@@ -342,9 +342,9 @@ describe('critical dialog flows', () => {
         version: '1.0.0',
         fileSize: '1 KB',
       },
+      data: importData,
       validation: { warnings: [] },
     });
-    mocks.readJsonFile.mockResolvedValueOnce({ success: true, data: importData });
     mocks.detectImportConflicts.mockReturnValueOnce({
       duplicateTaskIds: ['task-1'],
       duplicateBoardIds: [],

--- a/src/lib/utils/__tests__/fileHandling.test.ts
+++ b/src/lib/utils/__tests__/fileHandling.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { previewImportData } from '../fileHandling';
+
+function makeExportFile(): File {
+  const exportData = {
+    version: '1.0.0',
+    exportedAt: '2026-01-15T12:00:00.000Z',
+    tasks: [],
+    boards: [],
+  };
+  return new File([JSON.stringify(exportData)], 'export.json', {
+    type: 'application/json',
+  });
+}
+
+describe('previewImportData', () => {
+  it('returns the parsed data alongside the preview, so callers need only one read', async () => {
+    const result = await previewImportData(makeExportFile());
+
+    expect(result.success).toBe(true);
+    expect(result.preview?.taskCount).toBe(0);
+    expect(result.preview?.boardCount).toBe(0);
+    // The data was already parsed to build the preview — it must be returned
+    // so the caller doesn't have to read and parse the file a second time.
+    expect(result.data?.version).toBe('1.0.0');
+    expect(result.data?.tasks).toEqual([]);
+    expect(result.data?.boards).toEqual([]);
+  });
+});

--- a/src/lib/utils/fileHandling.ts
+++ b/src/lib/utils/fileHandling.ts
@@ -204,12 +204,13 @@ export async function previewImportData(file: File): Promise<{
     version: string;
     fileSize: string;
   };
+  data?: ExportData;
   validation?: ImportValidationResult;
   error?: string;
 }> {
   try {
     const result = await readJsonFile(file);
-    
+
     if (!result.success || !result.data) {
       return {
         success: false,
@@ -230,6 +231,8 @@ export async function previewImportData(file: File): Promise<{
     return {
       success: true,
       preview,
+      // Return the parsed data so callers don't read and parse the file again.
+      data: result.data,
       validation: result.validationResult,
     };
   } catch (error) {


### PR DESCRIPTION
Architecture review candidate **#7** (focused take). Independent of the other PRs; base `main`.

## Problem

`ImportDialog.handleFileSelect` choreographed two reads of the same file:

1. `previewImportData(file)` — reads, parses, and validates the file to build the preview, then **discards the parsed data**.
2. `readJsonFile(file)` — reads and parses the **same file again** just to get that data.

For a file up to the 10 MB limit, that's two full `FileReader` passes + two `JSON.parse` + two structure validations on one file select.

## Change

- `previewImportData` now returns the `data` it already parsed.
- `handleFileSelect` reuses `result.data` and no longer calls `readJsonFile` — one read, one parse, one validation.

## Scope note

The report's broader idea was a single `prepareImport` entry that also folds in conflict detection. The wizard genuinely needs user interaction between preview and conflict-resolution, so collapsing further would fight the UX. The **double-read** was the concrete, high-value, low-risk win — taken here. The deeper `processAdvancedImport` re-validation is left for when that path is next touched.

## Tests (TDD)

- `previewImportData` returns the parsed data alongside the preview (new `fileHandling.test.ts`)
- ImportDialog integration test updated to the single-read flow

## Verification
- ✅ Full suite: **518 tests passing**
- ✅ `tsc --noEmit` clean
- ✅ ESLint clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/kanban-todos/pull/83" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->