### PR TITLE
refactor: make KanbanColumn a presentation component

### DIFF
--- a/src/components/board/KanbanBoard.tsx
+++ b/src/components/board/KanbanBoard.tsx
@@ -5,6 +5,8 @@ import dynamic from "next/dynamic";
 import { Task } from "@/lib/types";
 import KanbanColumn from "../kanban/KanbanColumn";
 import { ColumnTabs } from "./ColumnTabs";
+import { useBoardStore } from "@/lib/stores/boardStore";
+import { useTaskStore } from "@/lib/stores/taskStore";
 
 // Lazy load drag-and-drop functionality
 const DragDropProvider = dynamic(() => import("../DragDropProvider").then(mod => ({ default: mod.DragDropProvider })), {
@@ -19,6 +21,15 @@ interface KanbanBoardProps {
 }
 
 export function KanbanBoard({ tasks, onNavigateToBoard, onAddTask }: KanbanBoardProps) {
+  // Board/search context lives here, in the orchestrator, and flows to the
+  // columns as props — the columns themselves stay presentation-only.
+  const { boards, currentBoardId } = useBoardStore();
+  const {
+    filters: { search, crossBoardSearch },
+    searchState: { highlightedTaskId },
+  } = useTaskStore();
+  const isCrossBoardSearch = crossBoardSearch && search.length > 0;
+
   // Mobile: which column is currently visible. Desktop ignores this — the grid
   // always shows all three columns side-by-side.
   const [activeColumn, setActiveColumn] = useState<Task['status']>('todo');
@@ -106,6 +117,10 @@ export function KanbanBoard({ tasks, onNavigateToBoard, onAddTask }: KanbanBoard
             title="To Do"
             tasks={todoTasks}
             status="todo"
+            boards={boards}
+            currentBoardId={currentBoardId}
+            highlightedTaskId={highlightedTaskId}
+            isCrossBoardSearch={isCrossBoardSearch}
             onNavigateToBoard={onNavigateToBoard}
             onAddTask={onAddTask}
             className={activeColumn === 'todo' ? 'flex' : 'hidden md:flex'}
@@ -115,6 +130,10 @@ export function KanbanBoard({ tasks, onNavigateToBoard, onAddTask }: KanbanBoard
             title="In Progress"
             tasks={inProgressTasks}
             status="in-progress"
+            boards={boards}
+            currentBoardId={currentBoardId}
+            highlightedTaskId={highlightedTaskId}
+            isCrossBoardSearch={isCrossBoardSearch}
             onNavigateToBoard={onNavigateToBoard}
             onAddTask={onAddTask}
             className={activeColumn === 'in-progress' ? 'flex' : 'hidden md:flex'}
@@ -124,6 +143,10 @@ export function KanbanBoard({ tasks, onNavigateToBoard, onAddTask }: KanbanBoard
             title="Done"
             tasks={doneTasks}
             status="done"
+            boards={boards}
+            currentBoardId={currentBoardId}
+            highlightedTaskId={highlightedTaskId}
+            isCrossBoardSearch={isCrossBoardSearch}
             onNavigateToBoard={onNavigateToBoard}
             onAddTask={onAddTask}
             className={activeColumn === 'done' ? 'flex' : 'hidden md:flex'}

--- a/src/components/kanban/KanbanColumn.tsx
+++ b/src/components/kanban/KanbanColumn.tsx
@@ -3,11 +3,9 @@
 import { memo } from "react";
 import { useDroppable, useDndContext } from "@dnd-kit/core";
 import isEqual from "fast-deep-equal";
-import { Task } from "@/lib/types";
+import { Task, Board } from "@/lib/types";
 import TaskCard from "./TaskCard";
 import { Plus } from "@/lib/icons";
-import { useBoardStore } from "@/lib/stores/boardStore";
-import { useTaskStore } from "@/lib/stores/taskStore";
 
 const STATUS_DOT_COLOR: Record<Task["status"], string> = {
   todo: "var(--info-500)",
@@ -19,18 +17,19 @@ interface KanbanColumnProps {
   title: string;
   tasks: Task[];
   status: Task["status"];
+  // Board/search context, derived by the parent and passed in so the column
+  // is a presentation component (no store reads) — testable through props and
+  // safely memoizable.
+  boards: Board[];
+  currentBoardId: string | null;
+  highlightedTaskId?: string;
+  isCrossBoardSearch: boolean;
   onNavigateToBoard?: (boardId: string, taskId: string) => void;
   onAddTask?: (status: Task["status"]) => void;
   className?: string;
 }
 
-function KanbanColumn({ title, tasks, status, onNavigateToBoard, onAddTask, className }: KanbanColumnProps) {
-  const { boards, currentBoardId } = useBoardStore();
-  const {
-    filters: { search: searchQuery, crossBoardSearch },
-    searchState: { highlightedTaskId },
-  } = useTaskStore();
-
+function KanbanColumn({ title, tasks, status, boards, currentBoardId, highlightedTaskId, isCrossBoardSearch, onNavigateToBoard, onAddTask, className }: KanbanColumnProps) {
   const { setNodeRef, isOver } = useDroppable({
     id: status,
     data: { type: "column", status },
@@ -44,9 +43,6 @@ function KanbanColumn({ title, tasks, status, onNavigateToBoard, onAddTask, clas
   const activeTask = active?.data?.current?.task as Task | undefined;
   const showDropPlaceholder =
     isOver && activeTask !== undefined && activeTask.status !== status;
-
-  const isSearchActive = searchQuery.length > 0;
-  const isCrossBoardSearch = crossBoardSearch && isSearchActive;
 
   return (
     <div

--- a/src/components/kanban/__tests__/KanbanColumn.test.tsx
+++ b/src/components/kanban/__tests__/KanbanColumn.test.tsx
@@ -2,8 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import KanbanColumn from '../KanbanColumn';
 import { Task } from '@/lib/types';
-import { useBoardStore } from '@/lib/stores/boardStore';
-import { useTaskStore } from '@/lib/stores/taskStore';
 
 // Mock dnd-kit so we can drive `isOver` and the active-drag context from tests.
 const mockUseDroppable = vi.fn();
@@ -24,19 +22,13 @@ vi.mock('../TaskCard', () => ({
   default: () => null,
 }));
 
-vi.mock('@/lib/stores/boardStore');
-vi.mock('@/lib/stores/taskStore');
-
-function setStores() {
-  (useBoardStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-    boards: [],
-    currentBoardId: 'board-1',
-  });
-  (useTaskStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-    filters: { search: '', crossBoardSearch: false },
-    searchState: { highlightedTaskId: undefined },
-  });
-}
+// KanbanColumn is now a presentation component — board/search context comes
+// in as props, so these tests no longer need to mock the stores.
+const columnContext = {
+  boards: [],
+  currentBoardId: 'board-1',
+  isCrossBoardSearch: false,
+};
 
 function setNoActiveDrag() {
   mockUseDroppable.mockReturnValue({ setNodeRef: vi.fn(), isOver: false });
@@ -63,13 +55,12 @@ function setActiveDragFromOtherColumn() {
 describe('KanbanColumn — empty state vs drop placeholder', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    setStores();
   });
 
   it('shows the empty-state copy when no drag is in progress', () => {
     setNoActiveDrag();
 
-    render(<KanbanColumn title="Done" tasks={[]} status="done" />);
+    render(<KanbanColumn title="Done" tasks={[]} status="done" {...columnContext} />);
 
     expect(screen.getByText(/no tasks yet/i)).toBeInTheDocument();
     expect(screen.queryByText(/drop to move task here/i)).not.toBeInTheDocument();
@@ -78,7 +69,7 @@ describe('KanbanColumn — empty state vs drop placeholder', () => {
   it('shows ONLY the drop placeholder (not the empty state) when a card from another column is hovering', () => {
     setActiveDragFromOtherColumn();
 
-    render(<KanbanColumn title="Done" tasks={[]} status="done" />);
+    render(<KanbanColumn title="Done" tasks={[]} status="done" {...columnContext} />);
 
     // Regression: previously both the empty state AND the drop placeholder
     // rendered simultaneously, creating two competing affordances for the


### PR DESCRIPTION
Architecture review candidate **#5** (focused take). Independent; base `main`.

## Problem

`KanbanColumn` read **both stores** (`useBoardStore`, `useTaskStore`) to derive, per task, its board, current-board flag, highlight state, and the cross-board-search flag — mixing container and presentation concerns. Consequences:

- Testing it required mocking both stores (see the old `KanbanColumn.test.tsx`).
- Its `memo(KanbanColumn, isEqual)` was undercut by the internal store subscriptions — props equality couldn't prevent re-renders the store drove.

## Change

- Lift the board/search reads into `board/KanbanBoard` (the orchestrator) and pass the derived context down as props: `boards`, `currentBoardId`, `highlightedTaskId`, `isCrossBoardSearch`.
- `KanbanColumn` is now presentation-only — no store reads. Its test drops the store mocks and drives it purely through props (the testability win, demonstrated).

## Scope note

The `onNavigateToBoard` prop-drill (BoardView → KanbanBoard → KanbanColumn → TaskCard) is left as-is. Converting it to a hook/context is a separate, larger change for less payoff, and would tangle with the navigation event surface. Deferred deliberately.

## Nature

Behaviour-preserving. The 19-test `BoardView.integration` suite (columns, tasks, cross-board badges) is the net and stays green.

## Verification
- ✅ Full suite: **517 tests passing**
- ✅ `tsc --noEmit` clean
- ✅ ESLint clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/kanban-todos/pull/84" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->