### PR TITLE
fix: celebrate a task completion only when the drag move persists

### DIFF
--- a/src/components/DragDropProvider.tsx
+++ b/src/components/DragDropProvider.tsx
@@ -70,28 +70,32 @@ export function DragDropProvider({
     onDragStart?.(event);
   };
 
-  const handleDragEnd = (event: DragEndEvent) => {
+  const handleDragEnd = async (event: DragEndEvent) => {
     const { active, over } = event;
+
+    // Clear the drag overlay and let the parent restore its layout immediately
+    // — the persistence below runs after, so the UI stays responsive.
+    setActiveTask(null);
+    onDragEnd?.(event);
 
     if (over && active.data.current?.type === 'task') {
       const taskId = active.id as string;
       const newStatus = over.id as Task['status'];
 
       if (newStatus && TASK_STATUSES.includes(newStatus)) {
-        // Celebrate only real transitions into 'done' (not done → done drops).
-        const previousStatus = tasks.find((t: Task) => t.id === taskId)?.status;
-        moveTask(taskId, newStatus);
-        if (newStatus === 'done' && previousStatus && previousStatus !== 'done') {
-          const completedTitle = tasks.find((t: Task) => t.id === taskId)?.title ?? '';
+        // Capture pre-move state before the store changes it.
+        const task = tasks.find((t: Task) => t.id === taskId);
+        const previousStatus = task?.status;
+        const completedTitle = task?.title ?? '';
+
+        // Celebrate only a real, *persisted* transition into 'done'. Previously
+        // the celebration fired immediately, even if the move never committed.
+        const moved = await moveTask(taskId, newStatus);
+        if (moved && newStatus === 'done' && previousStatus && previousStatus !== 'done') {
           celebrateTaskCompletion(completedTitle);
         }
       }
     }
-
-    setActiveTask(null);
-
-    // Call parent's drag end handler after task is moved
-    onDragEnd?.(event);
   };
 
   // Custom collision detection for better mobile accuracy

--- a/src/lib/stores/__tests__/taskStore.test.ts
+++ b/src/lib/stores/__tests__/taskStore.test.ts
@@ -313,6 +313,36 @@ describe('taskStore', () => {
       expect(tasks[0].completedAt).toBeUndefined();
       expect(tasks[0].progress).toBeUndefined();
     });
+
+    it('reports success so callers can act only on a persisted move', async () => {
+      useTaskStore.setState({
+        tasks: [{
+          id: 'task-1', title: 'Test', status: 'todo', boardId: 'board-1',
+          priority: 'low', tags: [], createdAt: new Date(), updatedAt: new Date(),
+        }],
+        filteredTasks: [],
+      });
+
+      const moved = await useTaskStore.getState().moveTask('task-1', 'in-progress');
+
+      expect(moved).toBe(true);
+    });
+
+    it('reports failure (and leaves the status unchanged) when the move cannot persist', async () => {
+      useTaskStore.setState({
+        tasks: [{
+          id: 'task-1', title: 'Test', status: 'todo', boardId: 'board-1',
+          priority: 'low', tags: [], createdAt: new Date(), updatedAt: new Date(),
+        }],
+        filteredTasks: [],
+      });
+      vi.mocked(taskDB.updateTask).mockRejectedValueOnce(new Error('db down'));
+
+      const moved = await useTaskStore.getState().moveTask('task-1', 'done');
+
+      expect(moved).toBe(false);
+      expect(useTaskStore.getState().tasks[0].status).toBe('todo');
+    });
   });
 
   describe('archiveTask', () => {

--- a/src/lib/stores/taskStore.crudActions.ts
+++ b/src/lib/stores/taskStore.crudActions.ts
@@ -125,9 +125,12 @@ export function createDeleteTask(_get: GetState, set: StoreSetter) {
 const TASK_COMPLETE_PROGRESS = 100; // progress value indicating task completion
 
 export function createMoveTask(get: GetState, set: StoreSetter) {
-  return async (taskId: string, newStatus: Task['status']) => {
+  // Returns whether the move actually persisted, so callers (e.g. the drag
+  // handler) can gate side effects like the completion celebration on a real,
+  // committed transition rather than firing them optimistically.
+  return async (taskId: string, newStatus: Task['status']): Promise<boolean> => {
     const task = get().tasks.find(t => t.id === taskId);
-    if (!task) return;
+    if (!task) return false;
 
     const updates: Partial<Task> = { status: newStatus, updatedAt: new Date() };
 
@@ -146,7 +149,12 @@ export function createMoveTask(get: GetState, set: StoreSetter) {
       await get().updateTask(taskId, updates);
     } catch (error: unknown) {
       set({ error: error instanceof Error ? error.message : 'Failed to move task' });
+      return false;
     }
+
+    // updateTask swallows persistence errors internally (it only sets error
+    // state), so confirm the status actually changed before reporting success.
+    return get().tasks.find(t => t.id === taskId)?.status === newStatus;
   };
 }
 

--- a/src/lib/stores/taskStore.ts
+++ b/src/lib/stores/taskStore.ts
@@ -78,7 +78,7 @@ interface TaskActions {
   addTask: (task: Omit<Task, 'id' | 'createdAt' | 'updatedAt'>) => Promise<void>;
   updateTask: (taskId: string, updates: Partial<Task>) => Promise<void>;
   deleteTask: (taskId: string) => Promise<void>;
-  moveTask: (taskId: string, newStatus: Task['status']) => Promise<void>;
+  moveTask: (taskId: string, newStatus: Task['status']) => Promise<boolean>;
   moveTaskToBoard: (taskId: string, targetBoardId: string) => Promise<void>;
   archiveTask: (taskId: string) => Promise<void>;
   unarchiveTask: (taskId: string) => Promise<void>;


### PR DESCRIPTION
Architecture review candidate **#4** (correctness core). Independent; base `main`.

## Problem

On drag-end, `handleDragEnd`:
- called `moveTask(taskId, newStatus)` **without awaiting it**, and
- fired `celebrateTaskCompletion` **immediately**, regardless of outcome.

So dropping a card into **Done** celebrated even when the move never persisted. `updateTask` swallows IndexedDB write failures into error state (no throw), so a failed move would still trigger confetti while the card silently reverted.

## Change

- `moveTask` now returns whether the move **actually committed** — it confirms the task's status changed (since `updateTask` swallows persistence errors rather than throwing). Interface: `Promise<void>` → `Promise<boolean>`.
- `handleDragEnd` awaits `moveTask` and celebrates **only a real, persisted** transition into Done.
- The drag overlay clears and the parent layout restores **immediately** (before the await), so the interaction stays responsive.

## Scope note

The report's broader idea was to consolidate the three drag state machines (dnd-kit's internal state, `DragDropProvider.activeTask`, `KanbanBoard.isDragging`) behind one `useDragLifecycle` seam. That's a larger refactor; this PR takes the **correctness core** — the un-awaited move + celebrate-on-failure bug — which is what made the candidate Strong.

## Tests (TDD)

- `moveTask` reports success on a persisted move
- `moveTask` reports failure (status unchanged) when the move can't persist

## Verification
- ✅ Full suite: **519 tests passing**
- ✅ `tsc --noEmit` clean
- ✅ ESLint clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/kanban-todos/pull/85" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->