### PR TITLE
ci: stop SonarCloud and Claude review from failing every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ jobs:
   quality:
     name: Lint, Type Check & Test
     runs-on: ubuntu-latest
+    env:
+      # Exposed at job level so the SonarCloud step can be conditionally
+      # skipped when the secret isn't configured (env is available in `if`).
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -32,7 +36,10 @@ jobs:
       - name: Test with coverage
         run: bun run test:coverage
 
+      # Skips cleanly when SONAR_TOKEN isn't configured, so a missing secret no
+      # longer fails the whole job. Runs automatically once the secret is added.
       - name: SonarCloud Scan
+        if: ${{ env.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarcloud-github-action@383f7e52eae3ab0510c3cb0e7d9d150bbaeab838 # v3.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,8 +37,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Pin a current model. The action's old default (claude-sonnet-4-20250514)
+          # is retired and now 404s. Bump this as newer models ship.
+          model: "claude-sonnet-4-6"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,8 +40,9 @@ jobs:
           additional_permissions: |
             actions: read
           
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Pin a current model. The action's old default (claude-sonnet-4-20250514)
+          # is retired and now 404s. Bump this as newer models ship.
+          model: "claude-sonnet-4-6"
           
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
Fixes the two CI checks that have been red on every PR for **infrastructure** reasons (not code) — surfaced on #86.

## SonarCloud Scan
Failed with `Set the SONAR_TOKEN env variable` because the `SONAR_TOKEN` secret isn't configured, which failed the entire **Lint, Type Check & Test** job (even though Lint/Type/Test themselves passed).

**Fix:** expose `SONAR_TOKEN` as job-level `env` and gate the step with `if: ${{ env.SONAR_TOKEN != '' }}`. It now **skips cleanly** when the secret is absent, and **runs automatically** if/when you add it.

## Claude review (`claude-review` check)
Failed with `API Error: 404 model: claude-sonnet-4-20250514` — the action set no `model`, so it used its retired default.

**Fix:** pin `model: "claude-sonnet-4-6"` (a current model) in both `claude-code-review.yml` and `claude.yml` (the latter has the same latent bug for `@claude` mentions).

## Verification
- ✅ All three workflow files validate as YAML
- This PR's own checks should demonstrate the fix: SonarCloud skips, the job passes, and the Claude review runs on the new model.

> Follow-up (your call, needs the secret value): if you want SonarCloud analysis to actually run, add the `SONAR_TOKEN` secret in repo settings — then this guard lets it run again with no further changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/kanban-todos/pull/87" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->