### PR TITLE
test: verify claude-review check (probe — do not merge)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,3 +27,5 @@ The removal of a board together with every task it owns, in a single IndexedDB t
 > **Domain expert:** They go too. A board *owns* its tasks — deleting the board cascades to them.
 > **Dev:** So a task could never sit around pointing at a board that's gone?
 > **Domain expert:** Right. That'd be an *orphaned task*, and that's a bug. The cascade is one atomic step precisely so it can't happen.
+
+<!-- CI verification probe (PR to confirm claude-review runs green); not for merge -->


### PR DESCRIPTION
Throwaway PR to confirm the `claude-review` check runs green now that #87 fixed the model and the workflow matches `main`. Touches only a doc comment — no workflow files. Will be closed without merging.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/kanban-todos/pull/88" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->