### PR TITLE
refactor(validation): drop dead validator wrappers + document sanitization boundary (#89)

### DIFF
--- a/src/lib/utils/exportImport/importData.ts
+++ b/src/lib/utils/exportImport/importData.ts
@@ -1,5 +1,26 @@
 /**
  * Import-related functions for application data
+ *
+ * ## Sanitization boundary (two distinct layers — do not conflate them)
+ *
+ * Imported data can be cleaned at two different levels, and callers should NOT
+ * try to sequence both themselves:
+ *
+ * 1. **Schema sanitization** — `sanitizeData` (validation.ts). Structural:
+ *    truncates over-length strings, drops fields the schema forbids, fills
+ *    defaults. Applied in the *live* import path here, by `sanitizeImportData`
+ *    (invoked from `processAdvancedImport`), and only when validation actually
+ *    found issues (`needsSanitization`).
+ *
+ * 2. **Entity XSS sanitization** — `sanitizeTaskData` / `sanitizeBoardData`
+ *    (security.ts). Strips HTML/dangerous content from title/description/tags.
+ *    Applied by `processImportData` (below) and, for user-authored data, at
+ *    write time in the store's crud actions.
+ *
+ * The live import flow (ImportDialog → `processAdvancedImport`) applies layer 1
+ * only. `processImportData` is the layer-2 entry point and is currently
+ * exercised only by tests — see issue #89 for the follow-up to either route the
+ * live flow through it or retire it.
  */
 
 import { Task, Board, Settings } from '@/lib/types';

--- a/src/lib/utils/validation.ts
+++ b/src/lib/utils/validation.ts
@@ -5,9 +5,6 @@
 
 import type { ExportData } from './exportImport';
 import {
-  taskSchema,
-  boardSchema,
-  settingsSchema,
   exportDataSchema,
   type ValidationSchema,
   type ValidationError,
@@ -301,18 +298,11 @@ export function getDefaultValue(schema: ValidationSchema): unknown {
 // Entity Validators
 // ============================================================================
 
-export function validateTask(task: unknown): DetailedValidationResult {
-  return validateSchema(task, taskSchema, 'task');
-}
-
-export function validateBoard(board: unknown): DetailedValidationResult {
-  return validateSchema(board, boardSchema, 'board');
-}
-
-export function validateSettings(settings: unknown): DetailedValidationResult {
-  return validateSchema(settings, settingsSchema, 'settings');
-}
-
+// validateExportData is the one entity validator with real callers (export +
+// import paths). The per-entity wrappers (validateTask/validateBoard/
+// validateSettings) were one-line pass-throughs over validateSchema with zero
+// callers, so they were removed — call validateSchema(data, <schema>, path)
+// directly with the schema from validationSchemas if you need one.
 export function validateExportData(data: unknown): DetailedValidationResult {
   return validateSchema(data, exportDataSchema, 'exportData');
 }


### PR DESCRIPTION
Closes #89.

## 1. Collapse the shallow entity-validator wrappers
`validateTask` / `validateBoard` / `validateSettings` were one-line pass-throughs over `validateSchema(data, schema, path)` with **zero callers** (verified across src + tests). Deleted. `validateExportData` is kept — it has real callers on the export and import paths and wasn't named in the issue.

## 2. Unify sanitization → **document the boundary** (the issue's explicit alternative)
While mapping the import flow I found the issue's premise doesn't hold for the **live** path:

- The live import is `ImportDialog → processAdvancedImport → resolveImportConflicts → importTasks`. That path applies **only schema sanitization** (`sanitizeData`, and only when validation found issues).
- The **XSS** pass (`sanitizeTaskData`/`sanitizeBoardData`) lives in `processImportData`, which is **called only by tests** — it isn't in the live flow.

So combining both into one `sanitizeImportedTask` chokepoint **wired into the live flow** would *add* XSS sanitization that isn't there today — a behaviour change the issue explicitly forbids. The behaviour-preserving move is the issue's stated alternative: a clear boundary doc at the top of `importData.ts` describing the two sanitization layers, which one runs where, and the `processImportData`-is-test-only gap.

## Verification
- ✅ Full suite **520 passing**, `tsc --noEmit` clean

## ⚠️ Surfaced for a decision (not changed here)
The live import flow does **not** XSS-sanitize imported task/board text. React escapes text by default so this isn't obviously exploitable, but it's a real gap and a deliberate behaviour question — left for a follow-up (route the live flow through `processImportData`, or retire `processImportData`). This is also the natural consolidation point for #92's `prepareImport()` work.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/kanban-todos/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->