### PR TITLE
refactor(import): add a single prepareImport() entry point (#92)

### DIFF
--- a/src/components/ImportDialog.tsx
+++ b/src/components/ImportDialog.tsx
@@ -4,8 +4,8 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } f
 import { useTaskStore } from "@/lib/stores/taskStore";
 import { useBoardStore } from "@/lib/stores/boardStore";
 import { useSettingsStore } from "@/lib/stores/settingsStore";
-import { previewImportData } from "@/lib/utils/fileHandling";
-import { processAdvancedImport, detectImportConflicts } from "@/lib/utils/exportImport";
+import { prepareImport } from "@/lib/utils/fileHandling";
+import { processAdvancedImport } from "@/lib/utils/exportImport";
 import { useImportState, ImportPreview } from "@/hooks/useImportState";
 import { FileSelectStep } from "./import/FileSelectStep";
 import { PreviewStep } from "./import/PreviewStep";
@@ -34,12 +34,6 @@ const STEP_DESCRIPTIONS = {
   complete: 'Import finished successfully',
 };
 
-const hasDetectedConflicts = (conflicts: ReturnType<typeof detectImportConflicts>) => (
-  (conflicts.duplicateTaskIds?.length ?? 0) > 0 ||
-  (conflicts.duplicateBoardIds?.length ?? 0) > 0 ||
-  (conflicts.defaultBoardConflicts?.length ?? 0) > 0
-);
-
 export function ImportDialog({ open, onOpenChange }: ImportDialogProps) {
   const { tasks, importTasks } = useTaskStore();
   const { boards, importBoards } = useBoardStore();
@@ -56,32 +50,31 @@ export function ImportDialog({ open, onOpenChange }: ImportDialogProps) {
     state.setWarnings([]);
 
     try {
-      const result = await previewImportData(file);
+      // One entry point reads + validates + previews the file (single read) and
+      // detects conflicts against the current data, so the dialog branches on a
+      // single result instead of sequencing the steps itself.
+      const prepared = await prepareImport(file, tasks, boards);
 
-      if (!result.success || !result.preview) {
-        state.setErrors([result.error || 'Failed to read import file']);
+      if (!prepared.success || !prepared.preview || !prepared.data) {
+        state.setErrors([prepared.error || 'Failed to read import file']);
         return;
       }
 
       const importPreview: ImportPreview = {
-        taskCount: result.preview.taskCount,
-        boardCount: result.preview.boardCount,
-        hasSettings: result.preview.hasSettings,
-        exportedAt: result.preview.exportedAt,
-        version: result.preview.version,
-        fileSize: result.preview.fileSize,
+        taskCount: prepared.preview.taskCount,
+        boardCount: prepared.preview.boardCount,
+        hasSettings: prepared.preview.hasSettings,
+        exportedAt: prepared.preview.exportedAt,
+        version: prepared.preview.version,
+        fileSize: prepared.preview.fileSize,
       };
 
-      // previewImportData already parsed the file — reuse its data instead of
-      // reading and parsing the same (potentially large) file a second time.
-      if (result.data) {
-        state.setImportData(result.data);
-      }
-
+      state.setImportData(prepared.data);
       state.setImportPreview(importPreview);
+      state.setConflicts(prepared.conflicts ?? null);
 
-      if (result.validation?.warnings && result.validation.warnings.length > 0) {
-        state.setWarnings(result.validation.warnings);
+      if (prepared.validation?.warnings && prepared.validation.warnings.length > 0) {
+        state.setWarnings(prepared.validation.warnings);
       }
     } catch (error) {
       state.setErrors([
@@ -93,10 +86,8 @@ export function ImportDialog({ open, onOpenChange }: ImportDialogProps) {
   const handlePreviewNext = () => {
     if (!state.importData) return;
 
-    const conflicts = detectImportConflicts(state.importData, tasks, boards);
-    const hasConflicts = hasDetectedConflicts(conflicts);
-
-    state.setConflicts(conflicts);
+    // Conflicts were already detected by prepareImport at file-select time.
+    const hasConflicts = state.hasConflicts();
     state.setCurrentStep(hasConflicts ? 'conflicts' : 'importing');
 
     if (!hasConflicts) {

--- a/src/components/__tests__/CriticalDialogs.test.tsx
+++ b/src/components/__tests__/CriticalDialogs.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   toastSuccess: vi.fn(),
   toastError: vi.fn(),
   previewImportData: vi.fn(),
+  prepareImport: vi.fn(),
   readJsonFile: vi.fn(),
   detectImportConflicts: vi.fn(),
   processAdvancedImport: vi.fn(),
@@ -44,6 +45,7 @@ vi.mock('sonner', () => ({
 
 vi.mock('@/lib/utils/fileHandling', () => ({
   previewImportData: mocks.previewImportData,
+  prepareImport: mocks.prepareImport,
   readJsonFile: mocks.readJsonFile,
 }));
 
@@ -332,7 +334,7 @@ describe('critical dialog flows', () => {
     };
     const file = new File(['{}'], 'backup.json', { type: 'application/json' });
 
-    mocks.previewImportData.mockResolvedValueOnce({
+    mocks.prepareImport.mockResolvedValueOnce({
       success: true,
       preview: {
         taskCount: 1,
@@ -344,11 +346,12 @@ describe('critical dialog flows', () => {
       },
       data: importData,
       validation: { warnings: [] },
-    });
-    mocks.detectImportConflicts.mockReturnValueOnce({
-      duplicateTaskIds: ['task-1'],
-      duplicateBoardIds: [],
-      defaultBoardConflicts: [],
+      conflicts: {
+        duplicateTaskIds: ['task-1'],
+        duplicateBoardIds: [],
+        defaultBoardConflicts: [],
+      },
+      hasConflicts: true,
     });
 
     render(<ImportDialog open onOpenChange={vi.fn()} />);

--- a/src/lib/utils/__tests__/fileHandling.test.ts
+++ b/src/lib/utils/__tests__/fileHandling.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { previewImportData } from '../fileHandling';
+import { previewImportData, prepareImport } from '../fileHandling';
+import type { Board } from '@/lib/types';
 
 function makeExportFile(): File {
   const exportData = {
@@ -13,6 +14,38 @@ function makeExportFile(): File {
   });
 }
 
+function makeExportFileWithBoard(boardId: string): File {
+  const exportData = {
+    version: '1.0.0',
+    exportedAt: '2026-01-15T12:00:00.000Z',
+    tasks: [],
+    boards: [
+      {
+        id: boardId,
+        name: 'Imported Board',
+        color: '#3b82f6',
+        isDefault: false,
+        order: 1,
+        createdAt: '2026-01-15T12:00:00.000Z',
+        updatedAt: '2026-01-15T12:00:00.000Z',
+      },
+    ],
+  };
+  return new File([JSON.stringify(exportData)], 'export.json', {
+    type: 'application/json',
+  });
+}
+
+const existingBoard: Board = {
+  id: 'board-1',
+  name: 'Existing Board',
+  color: '#10b981',
+  isDefault: true,
+  order: 0,
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+};
+
 describe('previewImportData', () => {
   it('returns the parsed data alongside the preview, so callers need only one read', async () => {
     const result = await previewImportData(makeExportFile());
@@ -25,5 +58,37 @@ describe('previewImportData', () => {
     expect(result.data?.version).toBe('1.0.0');
     expect(result.data?.tasks).toEqual([]);
     expect(result.data?.boards).toEqual([]);
+  });
+});
+
+describe('prepareImport', () => {
+  it('returns preview, parsed data, and conflict detection in a single result', async () => {
+    const result = await prepareImport(makeExportFile(), [], []);
+
+    expect(result.success).toBe(true);
+    expect(result.preview?.taskCount).toBe(0);
+    expect(result.data?.version).toBe('1.0.0');
+    // Conflict detection is folded into the single entry point so the dialog
+    // doesn't have to run detectImportConflicts itself as a separate step.
+    expect(result.conflicts).toBeDefined();
+    expect(result.hasConflicts).toBe(false);
+  });
+
+  it('flags hasConflicts when an imported board id collides with an existing one', async () => {
+    const result = await prepareImport(makeExportFileWithBoard('board-1'), [], [existingBoard]);
+
+    expect(result.success).toBe(true);
+    expect(result.conflicts?.duplicateBoardIds).toContain('board-1');
+    expect(result.hasConflicts).toBe(true);
+  });
+
+  it('reports failure (no conflicts run) when the file is invalid', async () => {
+    const badFile = new File(['not json'], 'bad.json', { type: 'application/json' });
+
+    const result = await prepareImport(badFile, [], []);
+
+    expect(result.success).toBe(false);
+    expect(result.hasConflicts).toBe(false);
+    expect(result.error).toBeTruthy();
   });
 });

--- a/src/lib/utils/fileHandling.ts
+++ b/src/lib/utils/fileHandling.ts
@@ -1,4 +1,11 @@
-import { ExportData, ImportValidationResult, validateImportData } from './exportImport';
+import { Task, Board } from '@/lib/types';
+import {
+  ExportData,
+  ImportValidationResult,
+  ImportConflicts,
+  validateImportData,
+  detectImportConflicts,
+} from './exportImport';
 
 // File size limits (in bytes)
 export const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
@@ -241,6 +248,61 @@ export async function previewImportData(file: File): Promise<{
       error: error instanceof Error ? error.message : 'Unknown error occurred',
     };
   }
+}
+
+export interface PreparedImport {
+  success: boolean;
+  preview?: {
+    taskCount: number;
+    boardCount: number;
+    hasSettings: boolean;
+    exportedAt: string;
+    version: string;
+    fileSize: string;
+  };
+  data?: ExportData;
+  validation?: ImportValidationResult;
+  conflicts?: ImportConflicts;
+  hasConflicts: boolean;
+  error?: string;
+}
+
+/**
+ * Single entry point for the import wizard: reads + validates + previews the
+ * file (one read) and detects conflicts against the existing data, returning
+ * everything the dialog needs in one result. Callers branch on this instead of
+ * sequencing previewImportData → detectImportConflicts themselves.
+ */
+export async function prepareImport(
+  file: File,
+  existingTasks: Task[],
+  existingBoards: Board[]
+): Promise<PreparedImport> {
+  const preview = await previewImportData(file);
+
+  if (!preview.success || !preview.data) {
+    return {
+      success: false,
+      error: preview.error,
+      validation: preview.validation,
+      hasConflicts: false,
+    };
+  }
+
+  const conflicts = detectImportConflicts(preview.data, existingTasks, existingBoards);
+  const hasConflicts =
+    (conflicts.duplicateTaskIds?.length ?? 0) > 0 ||
+    (conflicts.duplicateBoardIds?.length ?? 0) > 0 ||
+    (conflicts.defaultBoardConflicts?.length ?? 0) > 0;
+
+  return {
+    success: true,
+    preview: preview.preview,
+    data: preview.data,
+    validation: preview.validation,
+    conflicts,
+    hasConflicts,
+  };
 }
 
 /**


### PR DESCRIPTION
Closes #92.

## Problem
`ImportDialog` choreographed the import across handlers: `previewImportData` (read+validate+preview) in `handleFileSelect`, then a separate `detectImportConflicts` in `handlePreviewNext`. The component leaked the step ordering.

## Change
New single deep entry point:

```ts
prepareImport(file, existingTasks, existingBoards): Promise<PreparedImport>
// { success, preview, data, validation, conflicts, hasConflicts, error }
```

It reads the file **once**, validates, and detects conflicts up front. The dialog now branches on that one result:
- `handleFileSelect` → `prepareImport` → stores preview/data/validation/**conflicts**
- `handlePreviewNext` → just reads `state.hasConflicts()` and branches (no separate `detectImportConflicts`)
- the dialog's duplicate `hasDetectedConflicts` helper is **deleted** in favour of the existing `useImportState.hasConflicts()`

The wizard's interaction points (preview → conflict resolution → import) are unchanged.

## Placement note
`prepareImport` lives in `fileHandling.ts`, not `importData.ts` as the issue suggested: it needs `previewImportData`, and `importData.ts → fileHandling → exportImport(barrel) → importData` would be a **circular import**. `fileHandling` is the file→data orchestration layer, so it's the natural home.

## Verification (TDD)
- 3 new `prepareImport` unit tests (red → green): unified shape, conflict flagging, invalid-file path
- `CriticalDialogs.test.tsx` ImportDialog flow updated to mock the new entry point
- ✅ Full suite **523 passing**, `tsc --noEmit` clean

## ⚠️ Flagged follow-up (per decision — not changed here)
The **live** import flow doesn't XSS-sanitize imported task/board text — the XSS pass (`sanitizeTaskData`) lives only in test-only `processImportData`. Filing a separate security follow-up rather than changing behavior on the critical path here.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/kanban-todos/pull/97" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->