### PR TITLE
refactor(drag): consolidate drag state behind one useDragLifecycle seam (#90)

### DIFF
--- a/src/components/DragDropProvider.tsx
+++ b/src/components/DragDropProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useMemo } from "react";
 import {
   DndContext,
   DragEndEvent,
@@ -14,9 +14,7 @@ import {
   closestCenter,
   rectIntersection,
 } from "@dnd-kit/core";
-import { Task, TASK_STATUSES } from "@/lib/types";
-import { useTaskStore } from "@/lib/stores/taskStore";
-import { celebrateTaskCompletion } from "@/lib/utils/celebrateCompletion";
+import { Task } from "@/lib/types";
 import TaskCard from "./kanban/TaskCard";
 
 // Cache touch detection once at module level with SSR guard
@@ -24,26 +22,28 @@ const isTouchDevice = typeof window !== 'undefined' && 'ontouchstart' in window;
 
 interface DragDropProviderProps {
   children: React.ReactNode;
-  onDragStart?: (event: DragStartEvent) => void;
-  onDragEnd?: (event: DragEndEvent) => void;
+  // The drag interaction itself is owned by useDragLifecycle (see KanbanBoard).
+  // This component is now presentation-only: it wires the sensors/collision
+  // detection and renders the overlay for whatever task is being dragged.
+  activeTask: Task | null;
+  onDragStart: (event: DragStartEvent) => void;
+  onDragEnd: (event: DragEndEvent) => void;
   onDragOver?: (event: DragOverEvent) => void;
 }
 
 export function DragDropProvider({
   children,
+  activeTask,
   onDragStart,
   onDragEnd,
   onDragOver
 }: DragDropProviderProps) {
-  const [activeTask, setActiveTask] = useState<Task | null>(null);
-  const { tasks, moveTask } = useTaskStore();
-
   // Simple touch sensor configuration using cached detection
   const touchSensorConfig = useMemo(() => isTouchDevice
     ? { activationConstraint: { delay: 150, tolerance: 8 } }
     : { activationConstraint: { delay: 100, tolerance: 5 } },
   []);
-  
+
   // Configure drag sensors for both mouse and touch
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -53,50 +53,6 @@ export function DragDropProvider({
     }),
     useSensor(TouchSensor, touchSensorConfig)
   );
-
-  const handleDragStart = (event: DragStartEvent) => {
-    const { active } = event;
-    const task = tasks.find((t: Task) => t.id === active.id);
-    if (task) {
-      setActiveTask(task);
-
-      // Simple haptic feedback
-      if ('vibrate' in navigator) {
-        navigator.vibrate(50);
-      }
-    }
-
-    // Call parent's drag start handler first
-    onDragStart?.(event);
-  };
-
-  const handleDragEnd = async (event: DragEndEvent) => {
-    const { active, over } = event;
-
-    // Clear the drag overlay and let the parent restore its layout immediately
-    // — the persistence below runs after, so the UI stays responsive.
-    setActiveTask(null);
-    onDragEnd?.(event);
-
-    if (over && active.data.current?.type === 'task') {
-      const taskId = active.id as string;
-      const newStatus = over.id as Task['status'];
-
-      if (newStatus && TASK_STATUSES.includes(newStatus)) {
-        // Capture pre-move state before the store changes it.
-        const task = tasks.find((t: Task) => t.id === taskId);
-        const previousStatus = task?.status;
-        const completedTitle = task?.title ?? '';
-
-        // Celebrate only a real, *persisted* transition into 'done'. Previously
-        // the celebration fired immediately, even if the move never committed.
-        const moved = await moveTask(taskId, newStatus);
-        if (moved && newStatus === 'done' && previousStatus && previousStatus !== 'done') {
-          celebrateTaskCompletion(completedTitle);
-        }
-      }
-    }
-  };
 
   // Custom collision detection for better mobile accuracy
   const customCollisionDetection = (args: Parameters<typeof rectIntersection>[0]) => {
@@ -108,8 +64,8 @@ export function DragDropProvider({
     <DndContext
       sensors={sensors}
       collisionDetection={customCollisionDetection}
-      onDragStart={handleDragStart}
-      onDragEnd={handleDragEnd}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
       onDragOver={onDragOver}
     >
       {children}

--- a/src/components/__tests__/DragDropProvider.ios.test.tsx
+++ b/src/components/__tests__/DragDropProvider.ios.test.tsx
@@ -2,20 +2,13 @@ import { render, screen, fireEvent, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { DragDropProvider } from '../DragDropProvider'
 import { Task } from '@/lib/types'
-import { useTaskStore } from '@/lib/stores/taskStore'
 import TaskCard from '../kanban/TaskCard'
 
-// Mock the task store
-vi.mock('@/lib/stores/taskStore', () => ({
-  useTaskStore: vi.fn(),
-}))
-
-// Mock navigator.vibrate
-const mockVibrate = vi.fn()
-Object.defineProperty(navigator, 'vibrate', {
-  value: mockVibrate,
-  writable: true,
-})
+// DragDropProvider is now presentation-only: it wires @dnd-kit sensors and
+// renders the overlay. The drag *logic* (haptics, persistence, celebration)
+// lives in useDragLifecycle and is covered by useDragLifecycle.test.ts. These
+// tests verify the iOS-tuned TouchSensor activation by observing the onDragStart
+// the provider forwards from @dnd-kit.
 
 const mockTask: Task = {
   id: 'task-1',
@@ -29,22 +22,24 @@ const mockTask: Task = {
   updatedAt: new Date('2024-01-01'),
 }
 
-const mockTasks = [mockTask]
-const mockMoveTask = vi.fn()
+function renderProvider(
+  props: Partial<React.ComponentProps<typeof DragDropProvider>> = {}
+) {
+  return render(
+    <DragDropProvider
+      activeTask={null}
+      onDragStart={vi.fn()}
+      onDragEnd={vi.fn()}
+      {...props}
+    >
+      <TaskCard task={mockTask} />
+    </DragDropProvider>
+  )
+}
 
 describe('DragDropProvider iOS TouchSensor Tests', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    
-    // Mock useTaskStore implementation
-    ;(useTaskStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      tasks: mockTasks,
-      moveTask: mockMoveTask,
-    })
-  })
-
-  afterEach(() => {
-    vi.resetAllMocks()
   })
 
   describe('iOS Safari User Agent Detection', () => {
@@ -63,13 +58,8 @@ describe('DragDropProvider iOS TouchSensor Tests', () => {
         configurable: true,
       })
 
-      render(
-        <DragDropProvider>
-          <TaskCard task={mockTask} />
-        </DragDropProvider>
-      )
+      renderProvider()
 
-      // Verify component renders correctly on iOS
       expect(screen.getByText('Test Task')).toBeInTheDocument()
     })
 
@@ -79,92 +69,73 @@ describe('DragDropProvider iOS TouchSensor Tests', () => {
         configurable: true,
       })
 
-      render(
-        <DragDropProvider>
-          <TaskCard task={mockTask} />
-        </DragDropProvider>
-      )
+      renderProvider()
 
       expect(screen.getByText('Test Task')).toBeInTheDocument()
     })
   })
 
   describe('TouchSensor Configuration', () => {
-    it('should configure TouchSensor with iOS-optimized settings', () => {
-      const { container } = render(
-        <DragDropProvider>
-          <TaskCard task={mockTask} />
-        </DragDropProvider>
-      )
+    it('should render draggable children', () => {
+      const { container } = renderProvider()
 
       const dragElement = container.querySelector('[data-task-id="task-1"]')
       expect(dragElement).toBeInTheDocument()
     })
 
-    it('should handle touch events with proper activation constraints', async () => {
-      const { container } = render(
-        <DragDropProvider>
-          <TaskCard task={mockTask} />
-        </DragDropProvider>
-      )
+    it('should activate drag after the delay and forward onDragStart', async () => {
+      const onDragStart = vi.fn()
+      const { container } = renderProvider({ onDragStart })
 
       const dragElement = container.querySelector('[data-task-id="task-1"]') as Element
-      
-      // Simulate touch start
+
       fireEvent.touchStart(dragElement, {
         touches: [{ clientX: 100, clientY: 100, identifier: 1 }],
         targetTouches: [{ clientX: 100, clientY: 100, identifier: 1 }],
         changedTouches: [{ clientX: 100, clientY: 100, identifier: 1 }],
       })
 
-      // Wait for activation delay (200ms)
+      // Wait past the touch activation delay.
       await act(async () => {
         await new Promise(resolve => setTimeout(resolve, 250))
       })
 
-      // Verify haptic feedback was triggered
-      expect(mockVibrate).toHaveBeenCalledWith(50)
+      expect(onDragStart).toHaveBeenCalled()
     })
 
-    it('should activate drag after delay regardless of small movements', async () => {
-      const { container } = render(
-        <DragDropProvider>
-          <TaskCard task={mockTask} />
-        </DragDropProvider>
-      )
+    it('should activate drag despite small movements within tolerance', async () => {
+      const onDragStart = vi.fn()
+      const { container } = renderProvider({ onDragStart })
 
       const dragElement = container.querySelector('[data-task-id="task-1"]') as Element
-      
-      // Start touch
+
       fireEvent.touchStart(dragElement, {
         touches: [{ clientX: 100, clientY: 100, identifier: 1 }],
         targetTouches: [{ clientX: 100, clientY: 100, identifier: 1 }],
         changedTouches: [{ clientX: 100, clientY: 100, identifier: 1 }],
       })
 
-      // Move within tolerance (< 8px) - this should still activate after delay
+      // Move within tolerance (< 8px) — should still activate after the delay.
       fireEvent.touchMove(dragElement, {
         touches: [{ clientX: 105, clientY: 105, identifier: 1 }],
         targetTouches: [{ clientX: 105, clientY: 105, identifier: 1 }],
         changedTouches: [{ clientX: 105, clientY: 105, identifier: 1 }],
       })
 
-      // Wait past activation delay
       await act(async () => {
         await new Promise(resolve => setTimeout(resolve, 250))
       })
 
-      // Should trigger haptic feedback after delay even with small movements
-      expect(mockVibrate).toHaveBeenCalledWith(50)
+      expect(onDragStart).toHaveBeenCalled()
     })
   })
 
   describe('Touch Event Handling', () => {
-    it('should handle touchend events properly', async () => {
-      const mockOnDragEnd = vi.fn()
-      
+    it('should forward onDragEnd on touchend', async () => {
+      const onDragEnd = vi.fn()
+
       const { container } = render(
-        <DragDropProvider onDragEnd={mockOnDragEnd}>
+        <DragDropProvider activeTask={null} onDragStart={vi.fn()} onDragEnd={onDragEnd}>
           <TaskCard task={mockTask} />
           <div data-testid="drop-zone" data-droppable-id="in-progress">
             Drop Zone
@@ -174,92 +145,57 @@ describe('DragDropProvider iOS TouchSensor Tests', () => {
 
       const dragElement = container.querySelector('[data-task-id="task-1"]') as Element
 
-      // Start drag
       fireEvent.touchStart(dragElement, {
         touches: [{ clientX: 100, clientY: 100, identifier: 1 }],
       })
 
-      // Wait for activation
       await act(async () => {
         await new Promise(resolve => setTimeout(resolve, 250))
       })
 
-      // Move to drop zone
       fireEvent.touchMove(dragElement, {
         touches: [{ clientX: 200, clientY: 200, identifier: 1 }],
       })
 
-      // End touch over drop zone
       fireEvent.touchEnd(dragElement, {
         changedTouches: [{ clientX: 200, clientY: 200, identifier: 1 }],
       })
 
-      expect(mockOnDragEnd).toHaveBeenCalled()
+      expect(onDragEnd).toHaveBeenCalled()
     })
 
     it('should handle touchcancel events gracefully', async () => {
-      const { container } = render(
-        <DragDropProvider>
-          <TaskCard task={mockTask} />
-        </DragDropProvider>
-      )
+      const { container } = renderProvider()
 
       const dragElement = container.querySelector('[data-task-id="task-1"]') as Element
 
-      // Start drag
       fireEvent.touchStart(dragElement, {
         touches: [{ clientX: 100, clientY: 100, identifier: 1 }],
       })
 
-      // Wait for activation
       await act(async () => {
         await new Promise(resolve => setTimeout(resolve, 250))
       })
 
-      // Cancel touch - should not throw errors
       expect(() => {
         fireEvent.touchCancel(dragElement, {
           changedTouches: [{ clientX: 100, clientY: 100, identifier: 1 }],
         })
       }).not.toThrow()
-
-      // Verify haptic feedback was triggered during activation
-      expect(mockVibrate).toHaveBeenCalledWith(50)
-    })
-  })
-
-  describe('iOS-specific CSS Properties', () => {
-    it('should apply touch-action: none for proper touch handling', () => {
-      const { container } = render(
-        <DragDropProvider>
-          <TaskCard task={mockTask} />
-        </DragDropProvider>
-      )
-
-      const dragElement = container.querySelector('[data-task-id="task-1"]') as Element
-      
-      // Check if drag element is properly set up for touch
-      expect(dragElement).toBeInTheDocument()
-      expect(dragElement).toHaveAttribute('data-task-id', 'task-1')
     })
   })
 
   describe('Cross-device Compatibility', () => {
-    it('should work with both mouse and touch simultaneously', async () => {
-      const { container } = render(
-        <DragDropProvider>
-          <TaskCard task={mockTask} />
-        </DragDropProvider>
-      )
+    it('should work with both mouse and touch events', async () => {
+      const onDragStart = vi.fn()
+      const { container } = renderProvider({ onDragStart })
 
       const dragElement = container.querySelector('[data-task-id="task-1"]') as Element
 
-      // Test mouse events still work
       fireEvent.mouseDown(dragElement, { clientX: 100, clientY: 100 })
       fireEvent.mouseMove(dragElement, { clientX: 110, clientY: 110 })
       fireEvent.mouseUp(dragElement)
 
-      // Test touch events work
       fireEvent.touchStart(dragElement, {
         touches: [{ clientX: 100, clientY: 100, identifier: 1 }],
       })
@@ -268,42 +204,15 @@ describe('DragDropProvider iOS TouchSensor Tests', () => {
         await new Promise(resolve => setTimeout(resolve, 250))
       })
 
-      expect(mockVibrate).toHaveBeenCalledWith(50)
+      expect(onDragStart).toHaveBeenCalled()
     })
   })
 
   describe('Performance Considerations', () => {
-    it('should not create excessive event listeners', () => {
-      const { rerender } = render(
-        <DragDropProvider>
-          <TaskCard task={mockTask} />
-        </DragDropProvider>
-      )
-
-      // Re-render multiple times
-      for (let i = 0; i < 5; i++) {
-        rerender(
-          <DragDropProvider>
-            <TaskCard task={mockTask} />
-          </DragDropProvider>
-        )
-      }
-
-      // Component should still function correctly
-      expect(screen.getByText('Test Task')).toBeInTheDocument()
-    })
-
     it('should cleanup properly on unmount', () => {
-      const { unmount } = render(
-        <DragDropProvider>
-          <TaskCard task={mockTask} />
-        </DragDropProvider>
-      )
+      const { unmount } = renderProvider()
 
-      unmount()
-
-      // No errors should occur during cleanup
-      expect(true).toBe(true)
+      expect(() => unmount()).not.toThrow()
     })
   })
 })

--- a/src/components/board/KanbanBoard.tsx
+++ b/src/components/board/KanbanBoard.tsx
@@ -7,6 +7,7 @@ import KanbanColumn from "../kanban/KanbanColumn";
 import { ColumnTabs } from "./ColumnTabs";
 import { useBoardStore } from "@/lib/stores/boardStore";
 import { useTaskStore } from "@/lib/stores/taskStore";
+import { useDragLifecycle } from "@/hooks/useDragLifecycle";
 
 // Lazy load drag-and-drop functionality
 const DragDropProvider = dynamic(() => import("../DragDropProvider").then(mod => ({ default: mod.DragDropProvider })), {
@@ -27,16 +28,17 @@ export function KanbanBoard({ tasks, onNavigateToBoard, onAddTask }: KanbanBoard
   const {
     filters: { search, crossBoardSearch },
     searchState: { highlightedTaskId },
+    moveTask,
   } = useTaskStore();
   const isCrossBoardSearch = crossBoardSearch && search.length > 0;
 
   // Mobile: which column is currently visible. Desktop ignores this — the grid
   // always shows all three columns side-by-side.
   const [activeColumn, setActiveColumn] = useState<Task['status']>('todo');
-  // Drag state toggles a temporary "show all 3 columns scaled down" layout on
-  // mobile so a card can be dragged across columns even when only one is
-  // visible. Desktop is unaffected.
-  const [isDragging, setIsDragging] = useState(false);
+  // One seam owns the whole drag interaction: the overlay task, the mobile
+  // scaled-down layout flag (drag.isDragging), persistence, and the completion
+  // celebration. The columns just render; DragDropProvider just wires sensors.
+  const drag = useDragLifecycle(tasks, moveTask);
 
   // Memoize filtered tasks to avoid unnecessary recalculations
   const todoTasks = useMemo(() => tasks.filter(task => task.status === 'todo'), [tasks]);
@@ -70,16 +72,12 @@ export function KanbanBoard({ tasks, onNavigateToBoard, onAddTask }: KanbanBoard
     }
   }, [columns, announceColumnChange]);
 
-  const handleDragStart = useCallback(() => {
-    setIsDragging(true);
-  }, []);
-
-  const handleDragEnd = useCallback(() => {
-    setIsDragging(false);
-  }, []);
-
   return (
-    <DragDropProvider onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+    <DragDropProvider
+      activeTask={drag.activeTask}
+      onDragStart={drag.handleDragStart}
+      onDragEnd={drag.handleDragEnd}
+    >
       <div className="flex flex-col gap-4 h-full">
         {/* Screen reader announcer for column navigation */}
         <div
@@ -108,7 +106,7 @@ export function KanbanBoard({ tasks, onNavigateToBoard, onAddTask }: KanbanBoard
             Desktop: 3-col grid always. */}
         <div
           className={`flex md:grid md:grid-cols-3 gap-6 min-h-full board-animate-in ${
-            isDragging ? 'md:grid-cols-3 !grid grid-cols-3 !gap-2 scale-[0.85]' : ''
+            drag.isDragging ? 'md:grid-cols-3 !grid grid-cols-3 !gap-2 scale-[0.85]' : ''
           }`}
           role="region"
           aria-label="Kanban board columns"

--- a/src/hooks/__tests__/useDragLifecycle.test.ts
+++ b/src/hooks/__tests__/useDragLifecycle.test.ts
@@ -1,0 +1,81 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useDragLifecycle } from '../useDragLifecycle';
+import type { Task } from '@/lib/types';
+import { celebrateTaskCompletion } from '@/lib/utils/celebrateCompletion';
+
+vi.mock('@/lib/utils/celebrateCompletion', () => ({
+  celebrateTaskCompletion: vi.fn(),
+}));
+
+const mockVibrate = vi.fn();
+Object.defineProperty(navigator, 'vibrate', { value: mockVibrate, writable: true });
+
+const todoTask: Task = {
+  id: 'task-1',
+  title: 'Test Task',
+  status: 'todo',
+  priority: 'medium',
+  tags: [],
+  boardId: 'board-1',
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+};
+
+// Minimal @dnd-kit-shaped events — the hook only reads active.id, active.data,
+// and over.id.
+const startEvent = (id: string) => ({ active: { id } }) as never;
+const endEvent = (id: string, overId: string) =>
+  ({ active: { id, data: { current: { type: 'task' } } }, over: { id: overId } }) as never;
+
+describe('useDragLifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('handleDragStart sets the active task, flags dragging, and fires haptics', () => {
+    const { result } = renderHook(() => useDragLifecycle([todoTask], vi.fn().mockResolvedValue(true)));
+
+    act(() => result.current.handleDragStart(startEvent('task-1')));
+
+    expect(result.current.activeTask?.id).toBe('task-1');
+    expect(result.current.isDragging).toBe(true);
+    expect(mockVibrate).toHaveBeenCalledWith(50);
+  });
+
+  it('handleDragEnd clears state and persists the move', async () => {
+    const moveTask = vi.fn().mockResolvedValue(true);
+    const { result } = renderHook(() => useDragLifecycle([todoTask], moveTask));
+
+    act(() => result.current.handleDragStart(startEvent('task-1')));
+    await act(async () => {
+      await result.current.handleDragEnd(endEvent('task-1', 'in-progress'));
+    });
+
+    expect(result.current.activeTask).toBeNull();
+    expect(result.current.isDragging).toBe(false);
+    expect(moveTask).toHaveBeenCalledWith('task-1', 'in-progress');
+  });
+
+  it('celebrates only when a move into done actually persists', async () => {
+    const moveTask = vi.fn().mockResolvedValue(true);
+    const { result } = renderHook(() => useDragLifecycle([todoTask], moveTask));
+
+    await act(async () => {
+      await result.current.handleDragEnd(endEvent('task-1', 'done'));
+    });
+
+    expect(celebrateTaskCompletion).toHaveBeenCalledWith('Test Task');
+  });
+
+  it('does not celebrate when the move fails to persist (the #85 fix)', async () => {
+    const moveTask = vi.fn().mockResolvedValue(false);
+    const { result } = renderHook(() => useDragLifecycle([todoTask], moveTask));
+
+    await act(async () => {
+      await result.current.handleDragEnd(endEvent('task-1', 'done'));
+    });
+
+    expect(celebrateTaskCompletion).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useDragLifecycle.ts
+++ b/src/hooks/useDragLifecycle.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import type { DragStartEvent, DragEndEvent } from "@dnd-kit/core";
+import { Task, TASK_STATUSES } from "@/lib/types";
+import { celebrateTaskCompletion } from "@/lib/utils/celebrateCompletion";
+
+export interface DragLifecycle {
+  /** The task being dragged — drives the drag overlay. */
+  activeTask: Task | null;
+  /** True for the duration of any drag — drives the mobile scaled-down layout. */
+  isDragging: boolean;
+  handleDragStart: (event: DragStartEvent) => void;
+  handleDragEnd: (event: DragEndEvent) => Promise<void>;
+}
+
+/**
+ * Owns the whole drag interaction behind one seam: the overlay (activeTask),
+ * the mobile layout flag (isDragging), persistence (moveTask), and the
+ * completion celebration. Previously this was split across DragDropProvider's
+ * activeTask state and KanbanBoard's isDragging state, with @dnd-kit's own
+ * active/over as a third — callers had to coordinate all three.
+ */
+export function useDragLifecycle(
+  tasks: Task[],
+  moveTask: (taskId: string, newStatus: Task["status"]) => Promise<boolean>
+): DragLifecycle {
+  const [activeTask, setActiveTask] = useState<Task | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const handleDragStart = useCallback(
+    (event: DragStartEvent) => {
+      setIsDragging(true);
+
+      const task = tasks.find((t) => t.id === event.active.id);
+      if (task) {
+        setActiveTask(task);
+        // Simple haptic feedback on touch devices.
+        if ("vibrate" in navigator) {
+          navigator.vibrate(50);
+        }
+      }
+    },
+    [tasks]
+  );
+
+  const handleDragEnd = useCallback(
+    async (event: DragEndEvent) => {
+      const { active, over } = event;
+
+      // Clear the overlay and restore the layout immediately — the persistence
+      // below runs after, so the UI stays responsive.
+      setActiveTask(null);
+      setIsDragging(false);
+
+      if (over && active.data.current?.type === "task") {
+        const taskId = active.id as string;
+        const newStatus = over.id as Task["status"];
+
+        if (newStatus && TASK_STATUSES.includes(newStatus)) {
+          // Capture pre-move state before the store changes it.
+          const task = tasks.find((t) => t.id === taskId);
+          const previousStatus = task?.status;
+          const completedTitle = task?.title ?? "";
+
+          // Celebrate only a real, *persisted* transition into 'done' (#85).
+          const moved = await moveTask(taskId, newStatus);
+          if (moved && newStatus === "done" && previousStatus && previousStatus !== "done") {
+            celebrateTaskCompletion(completedTitle);
+          }
+        }
+      }
+    },
+    [tasks, moveTask]
+  );
+
+  return { activeTask, isDragging, handleDragStart, handleDragEnd };
+}


### PR DESCRIPTION
Closes #90.

## Problem
A single drag was spread across **three** state machines:
- `@dnd-kit`'s internal active/over,
- `DragDropProvider.activeTask` (`useState`, drag overlay),
- `KanbanBoard.isDragging` (`useState`, mobile scaled-down layout).

Understanding one drag meant reading all three, and callers coordinated the split.

## Change
New `useDragLifecycle(tasks, moveTask)` hook owns the whole interaction — overlay task, mobile layout flag, persistence, and the completion celebration:

```ts
const drag = useDragLifecycle(tasks, moveTask);   // in KanbanBoard
// drag.isDragging → mobile grid scale
<DragDropProvider
  activeTask={drag.activeTask}
  onDragStart={drag.handleDragStart}
  onDragEnd={drag.handleDragEnd} />
```

`DragDropProvider` becomes **presentation-only**: it wires the sensors + collision detection and renders the overlay. It no longer reads the store or owns drag state.

### Seam placement (the `ready-for-human` design call)
The hook lives in **`KanbanBoard`** (the orchestrator that already owns the layout), not in the lazy-loaded `DragDropProvider` — so the provider stays a thin `@dnd-kit` shell and the drag logic loads eagerly with the board it belongs to.

## Behaviour preserved
The drag logic — including the #85 fix (*celebrate only on a persisted move into `done`*) — is moved **verbatim** into the hook. `crudActions.ts` was **not** touched: `moveTask` already returns the success boolean (#85), which is all the seam needs.

## Verification
- New `useDragLifecycle.test.ts`: haptics on start, persistence on end, **celebrate-only-on-persist** (incl. the negative case where `moveTask` returns false)
- `DragDropProvider.ios.test.tsx` rewritten to test the provider's actual remaining job — iOS TouchSensor activation, observed via the forwarded `onDragStart`
- ✅ Full suite **522 passing**, `tsc --noEmit` clean

## ⚠️ Please do a manual drag check before merge
Per the issue (`ready-for-human` + "manual drag check"): drag a card across columns on **desktop** and **mobile**, confirm the overlay follows, the mobile scaled-3-col layout toggles, and the confetti fires only on a real drop into Done. Automated tests can't fully exercise real pointer/touch drag.

## Merge note
Touches `board/KanbanBoard.tsx`, also changed by #91 (PR #95). Different regions (props vs. drag state) — should auto-merge; merge #95 first and this rebases cleanly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/kanban-todos/pull/99" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->