### PR TITLE
test(e2e): add missing coverage for PWA, boards, import, and mobile

### DIFF
--- a/e2e/board-management.spec.ts
+++ b/e2e/board-management.spec.ts
@@ -70,6 +70,24 @@ test.describe('Board Management', () => {
     await expect(boardItem(page, boardName)).toHaveCount(0);
   });
 
+  test('deletes board with tasks after confirmation', async ({ page }) => {
+    const boardName = 'Board With Tasks';
+
+    await createBoard(page, boardName);
+    await selectBoard(page, boardName);
+    await createTask(page, 'Task on Board');
+    await createTask(page, 'Second Task');
+
+    await deleteBoard(page, boardName);
+
+    await expect(boardItem(page, boardName)).toHaveCount(0);
+    await expect(page.locator('.task-card', { hasText: 'Task on Board' })).toHaveCount(0);
+    await expect(page.locator('.task-card', { hasText: 'Second Task' })).toHaveCount(0);
+
+    await page.reload();
+    await expect(boardItem(page, boardName)).toHaveCount(0);
+  });
+
   test('cannot delete default board', async ({ page }) => {
     await openBoardMenu(page, 'Work Tasks');
     await expect(page.getByRole('menuitem', { name: 'Delete Board' })).toBeDisabled();

--- a/e2e/import-flow.spec.ts
+++ b/e2e/import-flow.spec.ts
@@ -115,6 +115,75 @@ test.describe('Import Flow', () => {
     await expect(page.getByRole('alert')).toBeVisible({ timeout: 5000 });
   });
 
+  test('shows error when task references a non-existent board', async ({ page }) => {
+    await openImport(page);
+
+    const payload = buildPayload({
+      boards: [],
+      tasks: [
+        {
+          id: 'orphaned-task-1',
+          title: 'Orphaned Task',
+          status: 'todo',
+          boardId: 'missing-board-id',
+          priority: 'medium',
+          tags: [],
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    await page.locator('input[type="file"]#import-file-input').setInputFiles({
+      name: 'orphaned-task.json',
+      mimeType: 'application/json',
+      buffer: payloadToBuffer(payload),
+    });
+
+    await expect(page.getByRole('alert')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(/non-existent board/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /Review import/i })).toHaveCount(0);
+  });
+
+  test('imports board description from backup', async ({ page }) => {
+    await openImport(page);
+
+    const boardId = 'described-board-' + Date.now();
+    const payload = buildPayload({
+      boards: [
+        {
+          id: boardId,
+          name: 'Described Import Board',
+          description: 'Imported board description',
+          color: '#6B4A87',
+          isDefault: false,
+          order: 50,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ],
+      tasks: [],
+    });
+
+    await uploadImportFile(page, payload);
+    await page.getByRole('button', { name: /Start import/i }).click();
+    await expect(page.getByRole('heading', { name: 'Import Complete!' })).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.getByRole('button', { name: /Close import/i }).click();
+
+    const item = page
+      .locator('[role="button"]', { has: page.getByText('Described Import Board', { exact: true }) })
+      .filter({ hasNotText: 'Move ' })
+      .first();
+    await expect(item).toBeVisible();
+    await expect(item).toContainText('Imported board description');
+
+    await page.reload();
+    await expect(item).toBeVisible();
+    await expect(item).toContainText('Imported board description');
+  });
+
   test('preview Back button returns to file select step', async ({ page }) => {
     await openImport(page);
 
@@ -151,8 +220,6 @@ test.describe('Import Flow', () => {
         autoArchiveDays: 30,
         enableNotifications: false,
         enableKeyboardShortcuts: true,
-        enableDebugMode: false,
-        enableDeveloperMode: false,
         searchPreferences: { defaultScope: 'current-board', rememberScope: true },
         accessibility: { highContrast: false, reduceMotion: false, fontSize: 'medium' },
       },

--- a/e2e/keyboard-shortcuts.spec.ts
+++ b/e2e/keyboard-shortcuts.spec.ts
@@ -77,6 +77,18 @@ test.describe('Keyboard Shortcuts', () => {
     await expect(page.getByRole('heading', { name: 'Work Tasks' })).toBeVisible();
   });
 
+  test('press Ctrl+2 switches to second board', async ({ page }) => {
+    const secondBoard = 'Second Board';
+
+    await createBoard(page, secondBoard);
+    await selectBoard(page, 'Work Tasks');
+    await expect(page.getByRole('heading', { name: 'Work Tasks' })).toBeVisible();
+
+    await page.keyboard.press('Control+2');
+
+    await expect(page.getByRole('heading', { name: secondBoard })).toBeVisible();
+  });
+
   test('press Cmd+1 switches to first board', async ({ page }) => {
     await createBoard(page, 'Second Board');
     await selectBoard(page, 'Second Board');

--- a/e2e/mobile-responsive.spec.ts
+++ b/e2e/mobile-responsive.spec.ts
@@ -33,6 +33,23 @@ test.describe('Mobile and Responsive', () => {
     await expect(page.getByRole('button', { name: /Open sidebar|Close sidebar/ })).toBeVisible();
   });
 
+  test('sidebar toggle closes and reopens the mobile sidebar', async ({ page }) => {
+    await boot(page, MOBILE);
+
+    const toggle = page.getByRole('button', { name: /Open sidebar|Close sidebar/ });
+
+    // Sidebar starts open — Settings should be reachable.
+    await expect(page.getByRole('button', { name: 'Settings', exact: true })).toBeVisible();
+
+    await toggle.click();
+    await expect(page.getByRole('button', { name: 'Open sidebar' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Settings', exact: true })).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Open sidebar' }).click();
+    await expect(page.getByRole('button', { name: 'Close sidebar' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Settings', exact: true })).toBeVisible();
+  });
+
   test('sidebar toggle is hidden on desktop', async ({ page }) => {
     await boot(page, DESKTOP);
 

--- a/e2e/pwa-features.spec.ts
+++ b/e2e/pwa-features.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect, type Page } from '@playwright/test';
+import { resetAppStorage } from './fixtures';
+
+async function boot(page: Page): Promise<void> {
+  await resetAppStorage(page);
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Work Tasks' })).toBeVisible();
+}
+
+test.describe('PWA Features', () => {
+  test('links to the web app manifest', async ({ page }) => {
+    await boot(page);
+
+    const manifest = page.locator('link[rel="manifest"]');
+    await expect(manifest).toHaveAttribute('href', '/manifest.json');
+  });
+
+  test('displays version indicator in the sidebar footer', async ({ page }) => {
+    await boot(page);
+
+    await expect(page.getByText(/^Cascade v/)).toBeVisible();
+    await expect(page.getByText(/\d{4}/)).toBeVisible();
+  });
+
+  test('version footer theme toggle switches the document theme', async ({ page }) => {
+    await boot(page);
+
+    await page.getByRole('button', { name: 'Dark theme' }).click();
+    await expect(page.locator('html')).toHaveClass(/dark/);
+
+    await page.getByRole('button', { name: 'Light theme' }).click();
+    await expect(page.locator('html')).toHaveClass(/light/);
+
+    await page.getByRole('button', { name: 'System theme' }).click();
+  });
+
+  test('does not show a service worker update banner on a fresh dev load', async ({ page }) => {
+    await boot(page);
+
+    await expect(page.getByText(/Update available/i)).toHaveCount(0);
+    await expect(page.getByRole('status')).toHaveCount(0);
+  });
+
+  test('manifest.json is served with expected PWA metadata', async ({ request }) => {
+    const response = await request.get('/manifest.json');
+    expect(response.ok()).toBe(true);
+
+    const manifest = (await response.json()) as {
+      name?: string;
+      short_name?: string;
+      display?: string;
+    };
+
+    expect(manifest.name).toBeTruthy();
+    expect(manifest.short_name).toBeTruthy();
+    expect(manifest.display).toBe('standalone');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `e2e/pwa-features.spec.ts` covering manifest link, version footer, theme toggle, and dev-mode update banner absence
- Extend board management tests to verify deleting a board with tasks (confirmation + persistence)
- Add keyboard shortcut coverage for `Ctrl+2` board switching and mobile sidebar open/close behavior
- Strengthen import flow tests for orphaned task validation and imported board description persistence

## Test plan
- [x] `bun run test:e2e` — 226 tests passing (~57s)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/kanban-todos/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->