### PR TITLE
fix(ui): resolve WCAG AA failures and design-system drift across all four surfaces

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,265 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-07-31T00:00:00Z",
+  "title": "Design System: Cascade",
+  "extensions": {
+    "colorMeta": {
+      "ink-indigo": {
+        "role": "primary",
+        "displayName": "Ink Indigo",
+        "canonical": "#3B4A8C",
+        "darkModeValue": "#7A8AD1",
+        "note": "Lifts to periwinkle in dark mode rather than darkening; a saturated indigo goes muddy against near-black.",
+        "tonalRamp": ["oklch(0.15 0.06 273)", "oklch(0.24 0.09 273)", "oklch(0.32 0.11 273)", "oklch(0.40 0.12 273)", "oklch(0.52 0.12 273)", "oklch(0.65 0.10 273)", "oklch(0.80 0.06 273)", "oklch(0.94 0.02 273)"]
+      },
+      "ink-indigo-deep": {
+        "role": "primary",
+        "displayName": "Ink Indigo Deep",
+        "canonical": "#2A3768",
+        "darkModeValue": "#6273C0",
+        "note": "Border and pressed companion to the accent.",
+        "tonalRamp": ["oklch(0.13 0.05 273)", "oklch(0.21 0.08 273)", "oklch(0.29 0.10 273)", "oklch(0.37 0.11 273)", "oklch(0.48 0.11 273)", "oklch(0.62 0.09 273)", "oklch(0.78 0.06 273)", "oklch(0.93 0.02 273)"]
+      },
+      "cool-stone": {
+        "role": "neutral",
+        "displayName": "Cool Stone",
+        "canonical": "#F4F4F0",
+        "darkModeValue": "#0F1018",
+        "note": "The page. Leans cool and faintly green — never a warm cream.",
+        "tonalRamp": ["oklch(0.17 0.005 110)", "oklch(0.28 0.005 110)", "oklch(0.40 0.005 110)", "oklch(0.52 0.005 110)", "oklch(0.64 0.005 110)", "oklch(0.76 0.005 110)", "oklch(0.87 0.005 110)", "oklch(0.96 0.005 110)"]
+      },
+      "paper": {
+        "role": "neutral",
+        "displayName": "Paper",
+        "canonical": "#FFFFFF",
+        "darkModeValue": "#181A24",
+        "note": "Card and panel surface — the material that sits on the stone.",
+        "tonalRamp": ["oklch(0.18 0.008 280)", "oklch(0.29 0.008 280)", "oklch(0.41 0.006 280)", "oklch(0.53 0.005 280)", "oklch(0.65 0.004 280)", "oklch(0.78 0.003 280)", "oklch(0.90 0.002 280)", "oklch(1.00 0 0)"]
+      },
+      "graphite": {
+        "role": "neutral",
+        "displayName": "Graphite",
+        "canonical": "#13141B",
+        "darkModeValue": "#E8E8EE",
+        "note": "Primary text with a cool undertone; also the hover border color, acting as the darkest rule available.",
+        "tonalRamp": ["oklch(0.17 0.015 280)", "oklch(0.28 0.014 280)", "oklch(0.39 0.012 280)", "oklch(0.50 0.010 280)", "oklch(0.62 0.008 280)", "oklch(0.74 0.006 280)", "oklch(0.86 0.004 280)", "oklch(0.95 0.002 280)"]
+      },
+      "oat": {
+        "role": "neutral",
+        "displayName": "Oat",
+        "canonical": "#DDDCDF",
+        "darkModeValue": "#2B2D38",
+        "note": "Tertiary surface and hover thumbnails.",
+        "tonalRamp": ["oklch(0.18 0.006 290)", "oklch(0.29 0.006 290)", "oklch(0.41 0.006 290)", "oklch(0.53 0.005 290)", "oklch(0.65 0.005 290)", "oklch(0.77 0.005 290)", "oklch(0.88 0.005 290)", "oklch(0.96 0.004 290)"]
+      },
+      "putty-300": {
+        "role": "neutral",
+        "displayName": "Putty 300",
+        "canonical": "#CFCFCC",
+        "darkModeValue": "#34363F",
+        "note": "The default rule color. The 1.5px signature border is this value at rest.",
+        "tonalRamp": ["oklch(0.18 0.004 280)", "oklch(0.29 0.004 280)", "oklch(0.41 0.004 280)", "oklch(0.53 0.004 280)", "oklch(0.65 0.004 280)", "oklch(0.76 0.004 280)", "oklch(0.85 0.004 280)", "oklch(0.94 0.003 280)"]
+      },
+      "putty-500": {
+        "role": "neutral",
+        "displayName": "Putty 500",
+        "canonical": "#6F6F75",
+        "darkModeValue": "#9A9AA0",
+        "note": "Muted text and every mono label.",
+        "tonalRamp": ["oklch(0.18 0.006 285)", "oklch(0.29 0.006 285)", "oklch(0.40 0.006 285)", "oklch(0.51 0.006 285)", "oklch(0.62 0.006 285)", "oklch(0.74 0.005 285)", "oklch(0.86 0.004 285)", "oklch(0.95 0.003 285)"]
+      },
+      "olive": {
+        "role": "tertiary",
+        "displayName": "Olive",
+        "canonical": "#788C5D",
+        "darkModeValue": "#9CB07A",
+        "note": "Success and the done status dot. Vegetal, never a signal green.",
+        "tonalRamp": ["oklch(0.20 0.03 130)", "oklch(0.30 0.045 130)", "oklch(0.40 0.055 130)", "oklch(0.50 0.062 130)", "oklch(0.58 0.062 130)", "oklch(0.70 0.055 130)", "oklch(0.83 0.035 130)", "oklch(0.94 0.015 130)"]
+      },
+      "rust": {
+        "role": "tertiary",
+        "displayName": "Rust",
+        "canonical": "#B04A3F",
+        "darkModeValue": "#D27468",
+        "note": "Destructive actions, errors, overdue. Earthy, not emergency red.",
+        "tonalRamp": ["oklch(0.20 0.05 32)", "oklch(0.30 0.08 32)", "oklch(0.40 0.10 32)", "oklch(0.52 0.12 32)", "oklch(0.62 0.11 32)", "oklch(0.73 0.09 32)", "oklch(0.85 0.05 32)", "oklch(0.95 0.02 32)"]
+      },
+      "ochre": {
+        "role": "tertiary",
+        "displayName": "Ochre",
+        "canonical": "#C78E3F",
+        "darkModeValue": "#D9A55F",
+        "note": "Warnings and the in-progress status dot.",
+        "tonalRamp": ["oklch(0.22 0.04 75)", "oklch(0.32 0.06 75)", "oklch(0.43 0.08 75)", "oklch(0.55 0.09 75)", "oklch(0.67 0.10 75)", "oklch(0.78 0.08 75)", "oklch(0.88 0.05 75)", "oklch(0.96 0.02 75)"]
+      },
+      "blueprint": {
+        "role": "tertiary",
+        "displayName": "Blueprint",
+        "canonical": "#5C7CA3",
+        "darkModeValue": "#7C9FD2",
+        "note": "Informational state and the todo status dot. Close to the accent in hue, far lower in chroma, so it never competes for 'this is the action'.",
+        "tonalRamp": ["oklch(0.20 0.03 250)", "oklch(0.30 0.045 250)", "oklch(0.41 0.06 250)", "oklch(0.53 0.07 250)", "oklch(0.64 0.065 250)", "oklch(0.75 0.05 250)", "oklch(0.86 0.03 250)", "oklch(0.95 0.012 250)"]
+      }
+    },
+    "typographyMeta": {
+      "display": { "displayName": "Display", "purpose": "Page titles, one per view. Serif. Scales to 3.75rem at the lg breakpoint." },
+      "headline": { "displayName": "Headline", "purpose": "Major section headings. Serif. Scales to 3rem at lg." },
+      "title": { "displayName": "Title", "purpose": "Subsection headings. Serif. The serif range ends here." },
+      "subtitle": { "displayName": "Subtitle", "purpose": "h4 and below — where type stops being a title and becomes interface. Sans." },
+      "body": { "displayName": "Body", "purpose": "Default text at 16px/1.55. Paragraphs use text-wrap: pretty." },
+      "card-title": { "displayName": "Card Title", "purpose": "Task card titles at 14px — deliberately smaller than body, because a card is a glanceable unit." },
+      "label": { "displayName": "Eyebrow Label", "purpose": "The single label voice across the entire system: 11px uppercase mono at 0.14em tracking." },
+      "mono": { "displayName": "Mono / Numeric", "purpose": "Counts and metadata. Always tabular-nums with slashed zero." }
+    },
+    "shadows": [
+      { "name": "hairline", "value": "0 1px 0 rgba(20,20,19,0.04)", "purpose": "The barely-there seat. Active sidebar items." },
+      { "name": "resting", "value": "0 1px 2px rgba(20,20,19,0.06)", "purpose": "Default card shadow. Almost subliminal." },
+      { "name": "raised", "value": "0 4px 14px rgba(20,20,19,0.08)", "purpose": "Focus-within and small popovers." },
+      { "name": "card-hover", "value": "0 10px 30px rgba(20,20,19,0.10)", "purpose": "Task card hover, paired with a -2px translate." },
+      { "name": "overlay", "value": "0 12px 28px rgba(20,20,19,0.12)", "purpose": "Dropdowns and popovers." },
+      { "name": "modal", "value": "0 24px 48px rgba(20,20,19,0.18)", "purpose": "Dialogs." },
+      { "name": "lift", "value": "0 32px 60px rgba(20,20,19,0.22)", "purpose": "The dragged card only — highest elevation in the system, reserved for the object literally in the person's hand." },
+      { "name": "focus-ring", "value": "0 0 0 3px rgba(59,74,140,0.18)", "purpose": "Composes with the above; not elevation." }
+    ],
+    "motion": [
+      { "name": "t-fast", "value": "120ms", "purpose": "Button background and shadow transitions." },
+      { "name": "t-base", "value": "150ms", "purpose": "Default state transition — cards, borders, hover lifts." },
+      { "name": "t-slow", "value": "300ms", "purpose": "Card entrance." },
+      { "name": "theme-crossfade", "value": "200ms ease", "purpose": "Light/dark swap on background-color, color, and border-color. Deliberately NOT disabled on theme change." },
+      { "name": "ease-out", "value": "cubic-bezier(0.2, 0.8, 0.2, 1)", "purpose": "Default easing for state transitions." },
+      { "name": "ease-pop", "value": "cubic-bezier(0.34, 1.56, 0.64, 1)", "purpose": "Overshoot easing, used sparingly." },
+      { "name": "ease-dialog", "value": "cubic-bezier(0.2, 0.7, 0.3, 1)", "purpose": "Modal enter (220ms) and iOS drag rotation (200ms)." },
+      { "name": "card-enter", "value": "300ms ease-out — opacity 0→1, translateY 8px→0, scale 0.98→1", "purpose": "Task card entrance." },
+      { "name": "drop-zone-pulse", "value": "1.5s ease-in-out infinite", "purpose": "Valid drop target breathing between 60% and 90% indigo tint." },
+      { "name": "reduce-motion", "value": "all durations forced to 0.01ms", "purpose": "Driven by the user-facing accessibility setting, not only the OS media query." }
+    ],
+    "breakpoints": [
+      { "name": "sm", "value": "640px" },
+      { "name": "md", "value": "768px" },
+      { "name": "lg", "value": "1024px" },
+      { "name": "xl", "value": "1280px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "The single primary action in a view. Ink Indigo fill; hover drops to 90% opacity.",
+      "html": "<button class=\"ds-btn-primary\">Add task</button>",
+      "css": ".ds-btn-primary { display: inline-flex; align-items: center; justify-content: center; gap: 8px; background: var(--primary, #3B4A8C); color: var(--primary-foreground, #FFFFFF); font-family: var(--font-sans, system-ui); font-size: 14px; font-weight: 500; border: none; border-radius: 8px; padding: 8px 16px; min-height: 36px; cursor: pointer; transition: background 150ms ease, box-shadow 150ms ease; } .ds-btn-primary:hover { background: color-mix(in oklab, var(--primary, #3B4A8C) 90%, transparent); } .ds-btn-primary:focus-visible { outline: 2px solid var(--ring, #3B4A8C); outline-offset: 2px; } .ds-btn-primary:active { transform: translateY(1px); }"
+    },
+    {
+      "name": "Outline Button",
+      "kind": "button",
+      "refersTo": "button-outline",
+      "description": "Secondary action. Putty surface inside a hairline rule; hover deepens the surface.",
+      "html": "<button class=\"ds-btn-outline\">Cancel</button>",
+      "css": ".ds-btn-outline { display: inline-flex; align-items: center; justify-content: center; gap: 8px; background: var(--surface, #EDEDEA); color: var(--foreground, #13141B); font-family: var(--font-sans, system-ui); font-size: 14px; font-weight: 500; border: 1px solid var(--border, #CFCFCC); border-radius: 8px; padding: 8px 16px; min-height: 36px; cursor: pointer; transition: background 150ms ease, border-color 150ms ease; } .ds-btn-outline:hover { background: var(--surface-2, #E1E1DE); border-color: var(--foreground, #13141B); } .ds-btn-outline:focus-visible { outline: 2px solid var(--ring, #3B4A8C); outline-offset: 2px; }"
+    },
+    {
+      "name": "Input Field",
+      "kind": "input",
+      "refersTo": "input-field",
+      "description": "Text input. On focus the border goes transparent so the ring reads as one clean stroke rather than a doubled edge.",
+      "html": "<input class=\"ds-input\" type=\"text\" placeholder=\"Search tasks\" />",
+      "css": ".ds-input { display: block; width: 100%; background: var(--surface, #EDEDEA); color: var(--foreground, #13141B); font-family: var(--font-sans, system-ui); font-size: 16px; border: 1px solid var(--border, #CFCFCC); border-radius: 8px; padding: 4px 12px; min-height: 36px; outline: none; transition: color 150ms ease, box-shadow 150ms ease; } .ds-input::placeholder { color: var(--muted, #6F6F75); } .ds-input:focus-visible { border-color: transparent; box-shadow: 0 0 0 2px var(--background, #F4F4F0), 0 0 0 4px var(--ring, #3B4A8C); } .ds-input[aria-invalid=\"true\"] { border-color: var(--destructive, #B04A3F); box-shadow: 0 0 0 3px rgba(176,74,63,0.20); } @media (min-width: 768px) { .ds-input { font-size: 14px; } }"
+    },
+    {
+      "name": "Task Card",
+      "kind": "card",
+      "refersTo": "card-task",
+      "description": "Signature component. Paper on a 1.5px rule; hover lifts 2px and darkens the border to Graphite rather than changing the surface.",
+      "html": "<article class=\"ds-task-card\" tabindex=\"0\"><div class=\"ds-task-card__title\">Draft the release notes</div><div class=\"ds-task-card__meta\"><span class=\"ds-dot ds-dot--progress\"></span><span>In progress &middot; 60%</span></div><div class=\"ds-task-card__track\"><div class=\"ds-task-card__fill\"></div></div></article>",
+      "css": ".ds-task-card { background: var(--card, #FFFFFF); border: 1.5px solid var(--border, #CFCFCC); border-radius: 12px; padding: 14px 14px 12px; box-shadow: 0 1px 2px rgba(20,20,19,0.06); transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease; cursor: grab; } .ds-task-card:hover { transform: translateY(-2px); box-shadow: 0 10px 30px rgba(20,20,19,0.10); border-color: var(--foreground, #13141B); } .ds-task-card:active { transform: translateY(0); box-shadow: 0 1px 2px rgba(20,20,19,0.06); } .ds-task-card:focus-visible { outline: none; box-shadow: 0 4px 14px rgba(20,20,19,0.08), 0 0 0 3px rgba(59,74,140,0.18); } .ds-task-card__title { font-family: var(--font-sans, system-ui); font-size: 14px; font-weight: 600; line-height: 1.35; letter-spacing: -0.005em; color: var(--foreground, #13141B); } .ds-task-card__meta { display: flex; align-items: center; gap: 6px; margin-top: 8px; font-family: var(--font-mono, ui-monospace); font-size: 11px; font-variant-numeric: tabular-nums slashed-zero; color: var(--muted, #6F6F75); } .ds-dot { width: 8px; height: 8px; border-radius: 999px; flex-shrink: 0; } .ds-dot--progress { background: var(--warning, #C78E3F); } .ds-task-card__track { margin-top: 10px; height: 4px; border-radius: 999px; background: var(--surface-2, #E1E1DE); overflow: hidden; } .ds-task-card__fill { width: 60%; height: 100%; background: var(--primary, #3B4A8C); } @media (hover: none) { .ds-task-card:hover { transform: none; box-shadow: 0 1px 2px rgba(20,20,19,0.06); border-color: var(--border, #CFCFCC); } }"
+    },
+    {
+      "name": "Kanban Column Header",
+      "kind": "custom",
+      "refersTo": "column-kanban",
+      "description": "Signature component. The count pill is the system in miniature — mono, tabular, hairline-ruled, full pill radius.",
+      "html": "<div class=\"ds-column\"><div class=\"ds-column__header\"><div class=\"ds-column__label\"><span class=\"ds-dot ds-dot--todo\"></span><span class=\"ds-eyebrow\">To do</span></div><span class=\"ds-count\">12</span></div></div>",
+      "css": ".ds-column { background: var(--surface, #EDEDEA); border: 1.5px solid var(--border, #CFCFCC); border-radius: 14px; padding: 16px 14px; } .ds-column__header { display: flex; align-items: center; justify-content: space-between; padding-bottom: 12px; } .ds-column__label { display: flex; align-items: center; gap: 8px; } .ds-dot { width: 8px; height: 8px; border-radius: 999px; flex-shrink: 0; } .ds-dot--todo { background: var(--chart-1, #5C7CA3); } .ds-eyebrow { font-family: var(--font-mono, ui-monospace); font-size: 11px; line-height: 15px; font-weight: 600; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted, #6F6F75); } .ds-count { font-family: var(--font-mono, ui-monospace); font-size: 11px; font-weight: 500; color: var(--muted, #6F6F75); background: var(--card, #FFFFFF); border: 1px solid var(--border, #CFCFCC); border-radius: 999px; padding: 1px 6px; font-variant-numeric: tabular-nums; }"
+    },
+    {
+      "name": "Sidebar Active Item",
+      "kind": "nav",
+      "refersTo": null,
+      "description": "The signature selection gesture: a 3px Ink Indigo bar down the left edge of a paper surface, radiused on its outer corners.",
+      "html": "<nav class=\"ds-nav\"><a class=\"ds-nav__item ds-nav__item--active\" href=\"#\"><span class=\"ds-nav__dot\"></span>Work Tasks</a><a class=\"ds-nav__item\" href=\"#\"><span class=\"ds-nav__dot ds-nav__dot--moss\"></span>Personal</a></nav>",
+      "css": ".ds-nav { display: flex; flex-direction: column; gap: 4px; background: var(--sidebar, #EDEDEA); padding: 8px; border-radius: 12px; } .ds-nav__item { position: relative; display: flex; align-items: center; gap: 10px; font-family: var(--font-sans, system-ui); font-size: 14px; color: var(--foreground, #13141B); text-decoration: none; padding: 8px 12px; border-radius: 8px; border: 1.5px solid transparent; transition: background 150ms ease; } .ds-nav__item:hover { background: var(--surface-2, #E1E1DE); } .ds-nav__item--active { background: var(--card, #FFFFFF); border-color: var(--border, #CFCFCC); box-shadow: 0 1px 0 rgba(20,20,19,0.04); } .ds-nav__item--active::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 3px; background: var(--primary, #3B4A8C); border-radius: 0 2px 2px 0; } .ds-nav__item:focus-visible { outline: 2px solid var(--ring, #3B4A8C); outline-offset: 2px; } .ds-nav__dot { width: 8px; height: 8px; border-radius: 999px; background: var(--dot-blue, #3F627A); flex-shrink: 0; } .ds-nav__dot--moss { background: var(--dot-moss, #5C6B3C); }"
+    },
+    {
+      "name": "Eyebrow Label",
+      "kind": "chip",
+      "refersTo": null,
+      "description": "The universal label voice — 11px uppercase mono at 0.14em tracking. There is no second label style in this system.",
+      "html": "<span class=\"ds-eyebrow-standalone\">Privacy first</span>",
+      "css": ".ds-eyebrow-standalone { display: inline-block; font-family: var(--font-mono, ui-monospace); font-size: 11px; line-height: 15px; font-weight: 600; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted, #6F6F75); }"
+    },
+    {
+      "name": "Badge",
+      "kind": "chip",
+      "refersTo": "badge-default",
+      "description": "Compact status or tag marker. Default carries the accent; destructive carries Rust.",
+      "html": "<span class=\"ds-badge\">High</span> <span class=\"ds-badge ds-badge--outline\">design</span>",
+      "css": ".ds-badge { display: inline-flex; align-items: center; gap: 4px; background: var(--primary, #3B4A8C); color: var(--primary-foreground, #FFFFFF); font-family: var(--font-sans, system-ui); font-size: 12px; font-weight: 500; border: 1px solid transparent; border-radius: 8px; padding: 2px 8px; white-space: nowrap; } .ds-badge--outline { background: transparent; color: var(--foreground, #13141B); border-color: var(--border, #CFCFCC); }"
+    },
+    {
+      "name": "Drag Ghost",
+      "kind": "custom",
+      "refersTo": null,
+      "description": "The one dashed form in the system — a reserved but unfilled space during drag.",
+      "html": "<div class=\"ds-drag-ghost\"></div>",
+      "css": ".ds-drag-ghost { height: 96px; border: 1.5px dashed var(--primary, #3B4A8C); background: color-mix(in oklab, rgba(59,74,140,0.14) 30%, transparent); border-radius: 14px; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Field Notebook",
+    "overview": "Cascade looks like a good notebook feels. Indigo ink on cool stone stock, ruled hairlines that actually mean something, mono labels stamped small and wide. A notebook is yours, works without power, and nobody else reads it — which is the same thing the product is, expressed in surfaces instead of architecture. Nothing here is trying to be impressive on first sight; it is trying to still be pleasant on the four-hundredth open.\n\nThe register is quiet, precise, and warm at once. Quiet: color is rationed, decoration is effectively zero, and the interface recedes behind the task. Precise: hairline rules, tabular numerals, and an unbroken 8px rhythm mean nothing sits at an accidental measurement. Warm: surfaces read as paper rather than glass, shadows are low-spread and soft rather than crisp, and a card lifts two pixels under the cursor because objects you handle should acknowledge being handled.\n\nSerif headings are part of the warmth, not a claim to being editorial. They soften a dense utilitarian tool the way a hand-written title softens a ruled page — this is a notebook, not a magazine, and the type should never start performing. The whole system is built from platform fonts only: no webfont ever loads, which is both a performance position and a privacy one, since a font request is a request to somebody else's server.",
+    "keyCharacteristics": [
+      "Signature 1.5px borders — the defining gesture, present on every meaningful surface",
+      "Cool stone page, white paper cards, deep indigo ink; a three-value world before any accent",
+      "Platform fonts only (system sans, ui-serif, ui-monospace) — zero webfont requests",
+      "Serif for h1–h3, sans for h4–h6 and body, mono for every label and every number",
+      "11px uppercase mono eyebrows at 0.14em tracking as the universal label voice",
+      "Borders define depth at rest; shadows are reserved for state changes",
+      "Light and dark are equal citizens, crossfading over 200ms rather than snapping"
+    ],
+    "rules": [
+      { "name": "The Rationed Ink Rule", "body": "Ink Indigo carries one primary action per view, the active-board rule, and focus. Its scarcity is what makes it legible as 'the important thing,' so it is never used decoratively, never for a surface fill, and never for a second competing button. The semantic pigments are exempt: olive, rust, ochre, and blueprint are information, and may appear as often as the data requires. Rationing applies to brand voice, not to meaning.", "section": "colors" },
+      { "name": "The Locked Dot Rule", "body": "The seven board dot hexes are user data, not theme. Someone chose 'Rose' for a board and that choice is persisted in their IndexedDB record. Never remap, restyle, or re-theme them across a design change; a redesign that shifts these values silently relabels every board the person already made.", "section": "colors" },
+      { "name": "The Cool Undertone Rule", "body": "Every neutral in this system leans cool. No warm greys, no cream, no sepia. A warm neutral introduced anywhere will read as a mistake next to the stone.", "section": "colors" },
+      { "name": "The Platform Font Rule", "body": "No webfont, ever. Not Google Fonts, not a self-hosted @font-face, not an icon font. Every face resolves from the visitor's own machine. This is a hard invariant with two justifications — a font request is a request to a third-party server, and a system with no font payload cannot have a flash of unstyled text.", "section": "typography" },
+      { "name": "The Mono Label Rule", "body": "Every label, eyebrow, count, and metadata string is 11px uppercase mono at 0.14em tracking. There is no second label style. If a new label appears and it isn't this, it's wrong.", "section": "typography" },
+      { "name": "The Tabular Numeral Rule", "body": "Any number a person might scan a column of — counts, progress, dates — gets font-variant-numeric: tabular-nums slashed-zero. Numbers that shift horizontally as they change are a defect, not a detail.", "section": "typography" },
+      { "name": "The Serif Ceiling Rule", "body": "Serif stops at h3. Below that, sans. A serif h5 makes the system look like a blog, which it isn't.", "section": "typography" },
+      { "name": "The Frame-First Rule", "body": "Reach for a border before a shadow. If a new surface needs separation, it gets a 1.5px Putty 300 rule; a shadow is added only if the surface must also read as above the thing behind it.", "section": "elevation" },
+      { "name": "The Lift-Is-Earned Rule", "body": "Elevation maps to interaction, not importance. The heaviest shadow in the system belongs to the card being dragged, not to the most important card.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do use the 1.5px border as the first tool for separating any new surface (Putty 300 at rest, Graphite on hover).",
+      "Do keep Ink Indigo to one primary action per view, plus focus and the active-board rule.",
+      "Do set every label, count, and metadata string in 11px uppercase mono at 0.14em tracking.",
+      "Do apply tabular-nums slashed-zero to any number that appears in a scannable column.",
+      "Do resolve type from the platform stacks (--font-serif, --font-sans, --font-mono).",
+      "Do land spacing on the 8px grid, using 4px only for micro-adjustments.",
+      "Do raise shadow alpha substantially in dark mode; the light-mode values vanish on near-black.",
+      "Do honor .reduce-motion and @media (hover: none) — both are already wired, and new motion must pass through them.",
+      "Do keep the tonal stack in order: Cool Stone page → Putty 100 column → Paper card.",
+      "Do preserve the 44px mobile touch minimum (48px on coarse-pointer iPad)."
+    ],
+    "donts": [
+      "Don't load a webfont. Not Google Fonts, not self-hosted, not an icon font. This is absolute.",
+      "Don't introduce a second brand color. Semantic pigments are the only additional hues, and only where they carry meaning.",
+      "Don't remap, restyle, or re-theme the seven board dot hexes — they are persisted user data.",
+      "Don't put a serif below h3, or a second label style anywhere.",
+      "Don't give a resting surface a heavy shadow. Elevation is a response to interaction.",
+      "Don't introduce a warm neutral, a cream, or a sepia; every neutral in this system leans cool.",
+      "Don't use pure black or pure white for text — Graphite (#13141B) and Paper are the endpoints.",
+      "Don't remove a focus outline. Every interactive element gets the 2px Ink Indigo ring at 2px offset.",
+      "Don't lock the viewport or disable pinch-zoom to solve an iOS input-zoom problem; the 16px input font-size already solves it.",
+      "Don't use a hard 0px corner, or an organic/blob shape."
+    ]
+  }
+}

--- a/.impeccable/live/config.json
+++ b/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+  "files": ["src/app/layout.tsx"],
+  "insertBefore": "</body>",
+  "commentSyntax": "jsx",
+  "cspChecked": true
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,470 @@
+---
+name: Cascade
+description: Ink on cool stone — a quiet, precisely-ruled kanban system built from platform fonts and 1.5px frames.
+colors:
+  ink-indigo: "#3B4A8C"
+  ink-indigo-deep: "#2A3768"
+  ink-indigo-tint: "rgba(59, 74, 140, 0.14)"
+  cool-stone: "#F4F4F0"
+  paper: "#FFFFFF"
+  graphite: "#13141B"
+  oat: "#DDDCDF"
+  putty-100: "#EDEDEA"
+  putty-200: "#E1E1DE"
+  putty-300: "#CFCFCC"
+  putty-500: "#6F6F75"
+  putty-700: "#3A3B41"
+  olive: "#788C5D"
+  rust: "#B04A3F"
+  ochre: "#C78E3F"
+  blueprint: "#5C7CA3"
+  dot-blue: "#3F627A"
+  dot-amber: "#B07820"
+  dot-green: "#4F7A4B"
+  dot-rose: "#A8412A"
+  dot-plum: "#6B4A87"
+  dot-clay: "#9A6240"
+  dot-moss: "#5C6B3C"
+typography:
+  display:
+    fontFamily: "ui-serif, Georgia, 'Times New Roman', Times, serif"
+    fontSize: "3rem"
+    fontWeight: 500
+    lineHeight: 1.1
+    letterSpacing: "-0.02em"
+  headline:
+    fontFamily: "ui-serif, Georgia, 'Times New Roman', Times, serif"
+    fontSize: "2.25rem"
+    fontWeight: 500
+    lineHeight: 1.2
+    letterSpacing: "-0.01em"
+  title:
+    fontFamily: "ui-serif, Georgia, 'Times New Roman', Times, serif"
+    fontSize: "1.875rem"
+    fontWeight: 500
+    lineHeight: 1.22
+    letterSpacing: "-0.008em"
+  subtitle:
+    fontFamily: "system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+    fontSize: "1.5rem"
+    fontWeight: 600
+    lineHeight: 1.25
+    letterSpacing: "-0.005em"
+  body:
+    fontFamily: "system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+    fontSize: "16px"
+    fontWeight: 400
+    lineHeight: 1.55
+    letterSpacing: "normal"
+  card-title:
+    fontFamily: "system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+    fontSize: "14px"
+    fontWeight: 600
+    lineHeight: 1.35
+    letterSpacing: "-0.005em"
+  label:
+    fontFamily: "ui-monospace, 'SF Mono', Menlo, Monaco, Consolas, monospace"
+    fontSize: "11px"
+    fontWeight: 600
+    lineHeight: "15px"
+    letterSpacing: "0.14em"
+  mono:
+    fontFamily: "ui-monospace, 'SF Mono', Menlo, Monaco, Consolas, monospace"
+    fontSize: "11px"
+    fontWeight: 500
+    lineHeight: 1.4
+    fontFeature: "'tnum' 1, 'zero' 1"
+rounded:
+  xs: "4px"
+  sm: "8px"
+  md: "12px"
+  lg: "14px"
+  xl: "20px"
+  pill: "999px"
+spacing:
+  sp-1: "4px"
+  sp-2: "8px"
+  sp-3: "12px"
+  sp-4: "16px"
+  sp-5: "24px"
+  sp-6: "32px"
+  sp-7: "48px"
+  sp-8: "64px"
+components:
+  button-primary:
+    backgroundColor: "{colors.ink-indigo}"
+    textColor: "{colors.paper}"
+    rounded: "{rounded.sm}"
+    padding: "8px 16px"
+    height: "36px"
+  button-primary-hover:
+    backgroundColor: "rgba(59, 74, 140, 0.9)"
+    textColor: "{colors.paper}"
+  button-outline:
+    backgroundColor: "{colors.putty-100}"
+    textColor: "{colors.graphite}"
+    rounded: "{rounded.sm}"
+    padding: "8px 16px"
+    height: "36px"
+  button-ghost:
+    backgroundColor: "transparent"
+    textColor: "{colors.graphite}"
+    rounded: "{rounded.sm}"
+    padding: "8px 16px"
+    height: "36px"
+  button-destructive:
+    backgroundColor: "{colors.rust}"
+    textColor: "#FFFFFF"
+    rounded: "{rounded.sm}"
+    padding: "8px 16px"
+    height: "36px"
+  input-field:
+    backgroundColor: "{colors.putty-100}"
+    textColor: "{colors.graphite}"
+    rounded: "{rounded.sm}"
+    padding: "4px 12px"
+    height: "36px"
+  card-task:
+    backgroundColor: "{colors.paper}"
+    textColor: "{colors.graphite}"
+    typography: "{typography.card-title}"
+    rounded: "{rounded.md}"
+    padding: "14px 14px 12px"
+  column-kanban:
+    backgroundColor: "{colors.putty-100}"
+    textColor: "{colors.graphite}"
+    rounded: "{rounded.lg}"
+    padding: "16px 14px"
+  column-count-pill:
+    backgroundColor: "{colors.paper}"
+    textColor: "{colors.putty-500}"
+    typography: "{typography.mono}"
+    rounded: "{rounded.pill}"
+    padding: "1px 6px"
+  badge-default:
+    backgroundColor: "{colors.ink-indigo}"
+    textColor: "{colors.paper}"
+    rounded: "{rounded.sm}"
+    padding: "2px 8px"
+---
+
+# Design System: Cascade
+
+## Overview
+
+**Creative North Star: "The Field Notebook"**
+
+Cascade looks like a good notebook feels. Indigo ink on cool stone stock, ruled hairlines that
+actually mean something, mono labels stamped small and wide. A notebook is yours, works without
+power, and nobody else reads it — which is the same thing the product is, expressed in surfaces
+instead of architecture. Nothing here is trying to be impressive on first sight; it is trying to
+still be pleasant on the four-hundredth open.
+
+The register is quiet, precise, and warm at once. Quiet: color is rationed, decoration is
+effectively zero, and the interface recedes behind the task. Precise: hairline rules, tabular
+numerals, and an unbroken 8px rhythm mean nothing sits at an accidental measurement. Warm: surfaces
+read as paper rather than glass, shadows are low-spread and soft rather than crisp, and a card
+lifts two pixels under the cursor because objects you handle should acknowledge being handled.
+
+Serif headings are part of the warmth, not a claim to being editorial. They soften a dense
+utilitarian tool the way a hand-written title softens a ruled page — this is a notebook, not a
+magazine, and the type should never start performing. The whole system is built from platform fonts
+only: no webfont ever loads, which is both a performance position and a privacy one, since a font
+request is a request to somebody else's server.
+
+**Key Characteristics:**
+
+- Signature 1.5px borders — the defining gesture, present on every meaningful surface
+- Cool stone page, white paper cards, deep indigo ink; a three-value world before any accent
+- Platform fonts only (system sans, `ui-serif`, `ui-monospace`) — zero webfont requests
+- Serif for h1–h3, sans for h4–h6 and body, mono for every label and every number
+- 11px uppercase mono eyebrows at 0.14em tracking as the universal label voice
+- Borders define depth at rest; shadows are reserved for state changes
+- Light and dark are equal citizens, crossfading over 200ms rather than snapping
+
+## Colors
+
+A three-material palette — stone, paper, ink — with a small set of pigments reserved for meaning.
+The system is nearly monochrome until information demands otherwise.
+
+### Primary
+
+- **Ink Indigo** (`#3B4A8C`): The single brand voice. Primary buttons, the 3px active-board rule in
+  the sidebar, focus rings, and the drag-target outline. In dark mode it lifts to a periwinkle
+  (`#7A8AD1`) rather than darkening, because a saturated indigo goes muddy against near-black.
+- **Ink Indigo Deep** (`#2A3768`): The pressed and bordered companion. Carries the 1.5px border on
+  primary buttons so the accent has an edge rather than a glow.
+
+### Secondary
+
+The system has no second brand color, and should not acquire one. What follows are semantic
+pigments, not a secondary palette.
+
+### Tertiary
+
+- **Olive** (`#788C5D`): Success and the `done` status dot. Muted and vegetal, never a signal green.
+- **Rust** (`#B04A3F`): Destructive actions, errors, and overdue state. Earthy, not emergency-red.
+- **Ochre** (`#C78E3F`): Warnings and the `in-progress` status dot.
+- **Blueprint** (`#5C7CA3`): Informational state and the `todo` status dot. Deliberately close to
+  the accent in hue but far lower in chroma, so it never competes for "this is the action."
+
+### Neutral
+
+- **Cool Stone** (`#F4F4F0`): The page. A stone that leans cool and slightly green — not a warm
+  cream, not a pure white.
+- **Paper** (`#FFFFFF`): Card and panel surfaces. The thing that sits *on* the stone.
+- **Graphite** (`#13141B`): Primary text, with a cool undertone that keeps it from reading as pure
+  black. Also the hover border color, where it acts as the darkest available rule.
+- **Oat** (`#DDDCDF`): Tertiary surfaces and hover thumbnails.
+- **Putty 100–700** (`#EDEDEA`, `#E1E1DE`, `#CFCFCC`, `#6F6F75`, `#3A3B41`): The cool putty scale.
+  100 is the column and sidebar surface, 300 is the default rule color, 500 is muted text and every
+  mono label, 700 is secondary text.
+
+### Board Dots (locked)
+
+- **Blue** (`#3F627A`), **Amber** (`#B07820`), **Green** (`#4F7A4B`), **Rose** (`#A8412A`),
+  **Plum** (`#6B4A87`), **Clay** (`#9A6240`), **Moss** (`#5C6B3C`): the categorical palette a person
+  picks from when labeling a board. All seven are desaturated to sit inside the notebook world
+  rather than on top of it.
+
+### Named Rules
+
+**The Rationed Ink Rule.** Ink Indigo carries one primary action per view, the active-board rule,
+and focus. Its scarcity is what makes it legible as "the important thing," so it is never used
+decoratively, never for a surface fill, and never for a second competing button. The semantic
+pigments are exempt: olive, rust, ochre, and blueprint are *information*, and may appear as often as
+the data requires. Rationing applies to brand voice, not to meaning.
+
+**The Locked Dot Rule.** The seven board dot hexes are user data, not theme. Someone chose "Rose"
+for a board and that choice is persisted in their IndexedDB record. Never remap, restyle, or
+re-theme them across a design change; a redesign that shifts these values silently relabels every
+board the person already made.
+
+**The Cool Undertone Rule.** Every neutral in this system leans cool. No warm greys, no cream, no
+sepia. A warm neutral introduced anywhere will read as a mistake next to the stone.
+
+## Typography
+
+**Display Font:** `ui-serif` (with Georgia, Times New Roman fallback)
+**Body Font:** `system-ui` (with -apple-system, Segoe UI, Roboto fallback)
+**Label/Mono Font:** `ui-monospace` (with SF Mono, Menlo, Monaco fallback)
+
+**Character:** A serif that arrives already installed, paired with the reader's own system sans and
+a mono reserved entirely for labels and numbers. The pairing is warm at the top of the page and
+utilitarian everywhere else — a titled notebook rather than a set magazine. Because all three are
+platform stacks, the exact faces differ per OS by design; the system is built on *roles*, not on
+one company's typeface.
+
+### Hierarchy
+
+- **Display** (serif, 500, 3rem → 3.75rem at `lg`, 1.1, -0.02em): Page titles. One per view.
+- **Headline** (serif, 500, 2.25rem → 3rem at `lg`, 1.2, -0.01em): Major section headings.
+- **Title** (serif, 500, 1.875rem → 2.25rem at `lg`, 1.22, -0.008em): Subsection headings. The
+  serif range ends here.
+- **Subtitle** (sans, 600, 1.5rem → 1.875rem at `lg`, 1.25, tight tracking): h4 and below switch to
+  sans — the point where type stops being a title and starts being an interface.
+- **Body** (sans, 400, 16px, 1.55): Default text. Paragraphs use `text-wrap: pretty`; all headings
+  use `text-wrap: balance`.
+- **Card Title** (sans, 600, 14px, 1.35, -0.005em): Task card titles. Deliberately smaller than
+  body — a card is a glanceable unit, not a paragraph.
+- **Label** (mono, 600, 11px, 0.14em, uppercase, Putty 500): The eyebrow. The single label voice
+  across the entire system.
+- **Mono/Numeric** (mono, 500, 11px, `tnum` + `zero`): Counts, metadata, and anything a person might
+  compare vertically.
+
+### Named Rules
+
+**The Platform Font Rule.** No webfont, ever. Not Google Fonts, not a self-hosted `@font-face`, not
+an icon font. Every face resolves from the visitor's own machine. This is a hard invariant with two
+justifications — a font request is a request to a third-party server, and a system with no font
+payload cannot have a flash of unstyled text.
+
+**The Mono Label Rule.** Every label, eyebrow, count, and metadata string is 11px uppercase mono at
+0.14em tracking. There is no second label style. If a new label appears and it isn't this, it's
+wrong.
+
+**The Tabular Numeral Rule.** Any number a person might scan a column of — counts, progress,
+dates — gets `font-variant-numeric: tabular-nums slashed-zero`. Numbers that shift horizontally as
+they change are a defect, not a detail.
+
+**The Serif Ceiling Rule.** Serif stops at h3. Below that, sans. A serif h5 makes the system look
+like a blog, which it isn't.
+
+## Layout
+
+Space is built on an 8px base with a 4px micro-step (`--sp-1` 4px through `--sp-8` 64px). Component
+padding lands on that grid almost everywhere; the deliberate exceptions are the task card
+(`14px 14px 12px`) and the kanban column (`16px 14px`), where the optical result beat the arithmetic
+one — the bottom is tightened because metadata text sits higher than its box.
+
+The board is a horizontal set of columns, each a bounded surface with its own header, count pill,
+and scroll region. On narrow viewports the columns become a scroll-snapping horizontal track
+(`scroll-snap-type: x mandatory`, `snap-stop: always`), so a swipe lands cleanly on one column
+rather than between two. The sidebar is a persistent navigation surface on desktop and a dismissible
+overlay on mobile.
+
+Density is comfortable rather than compressed. This is a tool for reading your own work at a glance,
+so cards breathe and columns keep their margins even when the board is full.
+
+Touch targets are 44px minimum on mobile via `.touch-target-mobile`, relaxing to natural size at
+`768px`; iPad at coarse pointer and ≥1024px goes to 48px. Buttons carry `min-h-[45px]` below the
+`sm` breakpoint and drop to their 36px desktop height above it — the mobile size is the honest one,
+and the desktop size is the compression.
+
+The single named breakpoint set is Tailwind's default (`sm` 640, `md` 768, `lg` 1024, `xl` 1280).
+
+## Elevation & Depth
+
+**Borders define; shadows respond.** At rest, this system is nearly flat: what separates a card from
+its column is a 1.5px rule and a one-pixel shadow, not elevation. Depth is a *reaction* — it appears
+when you hover, drag, focus, or open something, and it recedes the moment you stop. A card sitting
+still with a heavy shadow is off-system.
+
+There is also a genuine tonal stack underneath, and it should be preserved in that order: Cool Stone
+page → Putty 100 column → Paper card. Each step is a lighter, more foregrounded material, which is
+why cards read as objects on a surface even before any shadow is drawn.
+
+### Shadow Vocabulary
+
+- **Hairline** (`0 1px 0 rgba(20,20,19,0.04)`): The barely-there seat. Active sidebar items.
+- **Resting** (`0 1px 2px rgba(20,20,19,0.06)`): The default card shadow. Almost subliminal.
+- **Raised** (`0 4px 14px rgba(20,20,19,0.08)`): Focus-within and small popovers.
+- **Card Hover** (`0 10px 30px rgba(20,20,19,0.10)`): Paired with a -2px translate on task cards.
+- **Overlay** (`0 12px 28px rgba(20,20,19,0.12)`): Dropdowns and popovers.
+- **Modal** (`0 24px 48px rgba(20,20,19,0.18)`): Dialogs.
+- **Lift** (`0 32px 60px rgba(20,20,19,0.22)`): The dragged card only. The highest elevation in the
+  system, reserved for the one object literally in the person's hand.
+- **Focus ring** (`0 0 0 3px rgba(59,74,140,0.18)`): Not elevation, but composes with the above.
+
+In dark mode every shadow alpha roughly quadruples (0.04 → 0.30, 0.18 → 0.60), because a soft shadow
+on a near-black surface is invisible otherwise.
+
+### Named Rules
+
+**The Frame-First Rule.** Reach for a border before a shadow. If a new surface needs separation, it
+gets a 1.5px Putty 300 rule; a shadow is added only if the surface must also read as *above* the
+thing behind it.
+
+**The Lift-Is-Earned Rule.** Elevation maps to interaction, not importance. The heaviest shadow in
+the system belongs to the card being dragged, not to the most important card.
+
+## Shapes
+
+Corners are gently rounded and the radius grows with the surface: 4px on the smallest chips, 8px on
+buttons and inputs, 12px on task cards, 14px on kanban columns and drag ghosts, 20px on the largest
+panels, and a full pill (999px) on count badges. Nothing in the system is a hard 0px corner, and
+nothing organic or blobby appears anywhere.
+
+The defining form is not the corner, though — it's the **1.5px border**. Half a pixel heavier than
+the browser default hairline, which is exactly enough to read as a deliberate drawn rule rather than
+an incidental edge. It appears on task cards, kanban columns, active sidebar items, buttons, and
+inputs. Thinner 1px rules are used for internal dividers (stats-pill cells, count badges) where the
+line is separating rather than bounding.
+
+The drag ghost is the one dashed form in the system: a 1.5px dashed indigo outline at 14px radius
+over a 30%-strength indigo tint, marking a space that is reserved but not yet filled.
+
+Note a real second radius scale exists: shadcn primitives derive from `--radius: 0.625rem` (sm 6px,
+md 8px, lg 10px, xl 14px), which is why a shadcn `rounded-md` button lands at 8px and matches the
+Inkwell `--r-sm`. The two scales agree at the sizes that matter; prefer the `--r-*` scale when
+authoring new surfaces.
+
+## Components
+
+### Buttons
+
+- **Shape:** Softly rounded (8px), 36px tall on desktop, 45px minimum on mobile
+- **Primary:** Ink Indigo fill, Paper text; hover drops to 90% opacity of the same indigo
+- **Outline:** Putty 100 surface with a Putty 300 rule; hover deepens the surface to Putty 200
+- **Secondary:** Putty 200 surface, Graphite text; hover to 80% opacity
+- **Ghost:** No surface at rest; hover reveals a Putty 200 fill
+- **Destructive:** Rust fill, white text, with a rust-tinted focus ring
+- **Link:** Ink Indigo text with a 4px underline offset, underlined on hover
+- **Hover / Focus:** All buttons transition background, color, and shadow over 150ms. Focus is a
+  2px Ink Indigo ring at 2px offset — never a removed outline
+- **Icon:** Square, 45px on mobile and 36px on desktop; inner SVG locked to 16px
+
+### Cards / Containers
+
+- **Corner Style:** 12px on task cards, 14px on columns
+- **Background:** Paper cards on a Putty 100 column on a Cool Stone page
+- **Border:** 1.5px Putty 300, going to Graphite on hover — the border darkens rather than the
+  surface changing
+- **Shadow Strategy:** Resting at rest, Card Hover on hover paired with a -2px lift; `:active`
+  returns to flat immediately; `:focus-within` composes Raised with the focus ring
+- **Internal Padding:** `14px 14px 12px` on task cards, `16px 14px` on columns
+- **Motion:** Cards enter with `card-enter` — 300ms fade with an 8px rise and a 0.98 → 1 scale
+- **Touch:** All hover transforms are disabled under `@media (hover: none)`, so a tapped card on a
+  phone doesn't stick in a hover state
+
+### Inputs / Fields
+
+- **Style:** Putty 100 surface, 1.5px Putty 300 rule, 8px radius, 36px tall
+- **Focus:** 2px Ink Indigo ring at 2px offset, with the border going transparent so the ring reads
+  as a single clean stroke rather than a doubled edge
+- **Error:** `aria-invalid` drives a Rust border and a rust-tinted ring — the error state is bound
+  to the accessibility attribute, not to a separate visual prop
+- **Mobile:** Base font-size stays 16px to prevent iOS zoom-on-focus; it drops to 14px at `md`
+
+### Navigation (Sidebar)
+
+- **Surface:** Putty 100. In dark mode only, it gains a 20px backdrop blur at 1.3 saturation
+- **Active state:** Paper surface, 1.5px rule, Hairline shadow, and a 3px Ink Indigo bar down the
+  left edge, radiused 2px on its outer corners — the signature selection gesture
+- **Board rows:** Each carries its user-chosen dot color as a small filled circle
+- **Mobile:** Becomes a dismissible overlay
+
+### Kanban Column *(signature)*
+
+A bounded Putty 100 surface with a 1.5px rule and 14px corners, holding a header row, a count pill,
+and a scrolling card region. The **count pill** is the system in miniature: 11px mono with tabular
+numerals, Paper fill, 1px Putty 300 rule, full pill radius, `1px 6px` padding. The status dot beside
+each header maps to the semantic pigments — Blueprint for todo, Ochre for in-progress, Olive for
+done. When a column is a valid drop target it runs `drop-zone-pulse`, a 1.5s breathing loop between
+the indigo tint at 60% and 90% strength.
+
+### Task Card *(signature)*
+
+Paper on a 1.5px rule at 12px radius, with a 14px semibold sans title, mono metadata beneath, and an
+optional progress bar. Hover lifts it 2px and darkens the border to Graphite. While dragging on iOS
+it rotates -1.4° and lifts, carrying the heaviest shadow in the system — the card is in your hand,
+so it behaves like paper being moved.
+
+### Stats Pill
+
+A single inline row of cells divided by 1px Putty 200 rules, which reflows to a 2×2 grid below
+640px with the dividers re-drawn on the correct interior edges. A small piece of real craft worth
+preserving: the responsive collapse rebuilds the rules rather than dropping them.
+
+## Do's and Don'ts
+
+### Do:
+
+- **Do** use the 1.5px border as the first tool for separating any new surface (Putty 300 at rest,
+  Graphite on hover).
+- **Do** keep Ink Indigo to one primary action per view, plus focus and the active-board rule.
+- **Do** set every label, count, and metadata string in 11px uppercase mono at 0.14em tracking.
+- **Do** apply `tabular-nums slashed-zero` to any number that appears in a scannable column.
+- **Do** resolve type from the platform stacks (`--font-serif`, `--font-sans`, `--font-mono`).
+- **Do** land spacing on the 8px grid, using 4px only for micro-adjustments.
+- **Do** raise shadow alpha substantially in dark mode; the light-mode values vanish on near-black.
+- **Do** honor `.reduce-motion` and `@media (hover: none)` — both are already wired, and new motion
+  must pass through them.
+- **Do** keep the tonal stack in order: Cool Stone page → Putty 100 column → Paper card.
+- **Do** preserve the 44px mobile touch minimum (48px on coarse-pointer iPad).
+
+### Don't:
+
+- **Don't** load a webfont. Not Google Fonts, not self-hosted, not an icon font. This is absolute.
+- **Don't** introduce a second brand color. Semantic pigments are the only additional hues, and only
+  where they carry meaning.
+- **Don't** remap, restyle, or re-theme the seven board dot hexes — they are persisted user data.
+- **Don't** put a serif below h3, or a second label style anywhere.
+- **Don't** give a resting surface a heavy shadow. Elevation is a response to interaction.
+- **Don't** introduce a warm neutral, a cream, or a sepia; every neutral in this system leans cool.
+- **Don't** use pure black or pure white for text — Graphite (`#13141B`) and Paper are the endpoints.
+- **Don't** remove a focus outline. Every interactive element gets the 2px Ink Indigo ring at 2px
+  offset.
+- **Don't** lock the viewport or disable pinch-zoom to solve an iOS input-zoom problem; the 16px
+  input font-size already solves it.
+- **Don't** use a hard 0px corner, or an organic/blob shape.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,169 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+Two audiences, both real, in this order of authority:
+
+1. **The maintainer as daily driver.** Cascade is used every day for actual task management. Real workflow sets the requirements — if a change makes daily use worse, it is wrong regardless of how it demos.
+2. **The public visitor arriving cold.** Someone who wants a capable task board without creating an account or paying a subscription. They land with no context, no onboarding call, and no support channel, so the app has to be legible on first contact and survive being figured out alone.
+
+The two audiences are not in tension by default, but when they conflict, daily-use quality wins and the cold-arrival case is solved by making the app clearer rather than by adding guidance layers.
+
+## Product Purpose
+
+A kanban task manager that runs entirely in the visitor's browser. Boards hold tasks; tasks move
+`todo → in-progress → done` by drag-and-drop; completed work is archived rather than deleted.
+
+Success is a task board someone trusts enough to use daily — fast, private, and available offline —
+without ever having created an account or handed their task list to anyone.
+
+## Positioning
+
+**Local-only by architecture, permanently.** Task data lives in the visitor's browser (IndexedDB)
+and is never transmitted. There is no backend, no account system, and no sync service — and this is
+a closed decision, not a current-state limitation. Accounts, server-side storage, and cloud sync are
+explicitly out of scope for the life of the product.
+
+This is the claim a neighboring task app cannot truthfully copy while operating a server. Most
+privacy-forward competitors are trust-based: they *promise* not to read your data. Cascade's version
+is structural — there is no server that could read it, and the MIT-licensed source can be audited to
+confirm it. Every architectural decision downstream (static export, IndexedDB, JSON export/import)
+is a consequence of this position rather than an independent choice.
+
+JSON export/import is the shipped mechanism for backup and for moving data between browsers or
+devices.
+
+## Operating Context
+
+- **Single browser profile per data set.** Data is bound to the browser's IndexedDB. It does not
+  follow the visitor across devices or browsers except through explicit JSON export/import.
+- **Offline and installable.** Runs without a network connection and can be installed to the home
+  screen or desktop.
+- **Deployed as static files.** Primary deployment is `cascade.vinny.dev` (S3 + CloudFront); also
+  containerized (`Dockerfile`, nginx on port 8080) for self-hosting.
+- **Keyboard-driven use is a first-class path**, not an accessibility afterthought: `N` / `Ctrl+K`
+  create a task, `Ctrl+1–9` switch boards, `H` opens shortcuts, `F1` opens the guide, `Ctrl+,` opens
+  settings.
+- **Supported browsers:** Chrome/Chromium 90+, Firefox 88+, Safari 14+, Edge 90+, including iOS
+  Safari, where touch drag-and-drop needs device-specific activation constraints.
+
+## Capabilities and Constraints
+
+### Confirmed capabilities
+
+- Unlimited boards, each with a name, description, color, and icon. One board is the default board
+  and cannot be deleted.
+- Tasks with title, description, status, priority (`low`/`medium`/`high`), tags (max 10), due date,
+  and a 0–100 progress value that is meaningful only while `in-progress`.
+- Drag-and-drop between columns; move tasks between boards.
+- Search and filter by text, tag, priority, status, and overdue, scoped to the current board or
+  across all boards.
+- Archive, manual and automatic (default: completed tasks older than 30 days; configurable 1–365).
+- JSON export/import with conflict resolution.
+- Share a task's details by email or clipboard.
+- Due-date browser notifications (polling every 5 minutes; due-within-1-hour and overdue).
+- Light/dark/system theming.
+- PWA install and offline operation.
+
+### Hard constraints — future work must not break these
+
+- **No runtime backend.** Ships as a static export (`output: 'export'`). No SSR, no API routes, no
+  server-side runtime. Any feature requiring a server is out of scope by definition.
+- **No task data leaves the browser.** No analytics, telemetry, error reporting, or third-party
+  tracking of any kind. Verified: no analytics, telemetry, or error-reporting library is present in
+  the source.
+- **WCAG 2.1 AA.** See Accessibility & Inclusion.
+- **The Cascade name and `cascade.vinny.dev`.** See Brand Commitments.
+
+### Terminology
+
+The domain language is binding and documented in `CONTEXT.md`. In short: **board** (not list,
+project, or workspace), **task** (not todo, item, or card), a board **owns** its tasks, deleting a
+board **cascades** to them atomically, and an **orphaned task** is always a bug, never a valid state.
+
+### Explicitly undecided
+
+- **PWA / offline / installability is shipped but tradeable.** It works today and should not be
+  broken casually, but it is deliberately *not* a hard constraint: a future capability is allowed to
+  win a trade-off against offline support. Do not treat it as core, and do not quietly retire it
+  either.
+
+## Brand Commitments
+
+- **Name:** Cascade. Package name is `kanban-todos`; the product name is Cascade everywhere a person
+  can see it.
+- **Domain:** `cascade.vinny.dev`.
+- **Icon:** `public/images/cascade-icon.svg`.
+- **License:** MIT. The source is public, and "audit it yourself" is an actual product argument
+  rather than a footnote — keep it true.
+- **Voice — binding.** The register shipped on `/about` is the standard for all future copy: short
+  declaratives, concrete nouns, no hedging, no marketing inflation. "IndexedDB local storage. No
+  account. No server. No tracking. Ever." Copy states what is true and stops. It does not reach for
+  superlatives, and it does not soften a technical fact into a vague benefit.
+
+## Evidence on Hand
+
+**Real, present, and usable:**
+
+- Public MIT-licensed source: `github.com/vscarpenter/kanban-todos` (MIT, © 2025 Cascade Task
+  Management).
+- Live deployment at `cascade.vinny.dev`.
+- Shipped marketing surface at `/about`, plus `/install` and `/privacy` routes.
+- Open-graph image: `public/images/og-image.png` (1200×630) and `og-image.svg`.
+- Product icon: `public/images/cascade-icon.svg`; favicon `public/images/favicon.svg`.
+- Documentation: `docs/` (user guide, getting started, installation, developer guide, API reference,
+  testing guide), `openwiki/`, five ADRs in `docs/adr/`, and `CONTEXT.md` for domain language.
+- Realistic sample data: `sample-export.json`.
+- Test suites: Vitest unit tests and Playwright E2E specs in `e2e/`.
+
+**Absences future work must not fabricate:**
+
+- **No usage data of any kind.** The no-tracking commitment means there are no analytics, no user
+  counts, no retention numbers, no funnel data. Never state or imply a usage metric.
+- **No testimonials, named customers, reviews, press coverage, or case studies.** None exist. Do not
+  invent them, and do not invent placeholder personas presented as real people.
+- **No performance benchmarks** beyond what can be measured on demand. The "~388kB bundle" figure in
+  `CLAUDE.md` is an undated claim; re-measure before repeating it.
+- **PWA screenshots are declared but missing.** `public/manifest.json` references
+  `/images/screenshot-mobile.png` (390×844) and `/images/screenshot-desktop.png` (1280×720), and
+  neither file exists in `public/images/`. Treat these as assets to be produced, not as available
+  material.
+- **No pricing, plans, or commercial terms.** The product is free and MIT-licensed; there is no
+  business model to describe.
+
+## Product Principles
+
+1. **The architecture is the privacy promise.** Prefer solutions that make a privacy violation
+   structurally impossible over solutions that require trusting a policy. When a feature can only
+   work with a server, the feature loses.
+2. **Daily use outranks demonstration.** The board is a tool someone reaches for many times a day.
+   Speed, low friction, and predictability beat anything that is impressive once and tiresome on the
+   fiftieth use.
+3. **Legible without a tour.** A cold visitor has no onboarding call and no support. Solve confusion
+   by making the interface clearer, not by adding another explanatory layer on top of it.
+4. **The user's data is theirs to take.** Export must stay complete and lossless. Anything that makes
+   data harder to get out is a regression, regardless of what it makes easier inside the app.
+5. **Say the true thing plainly.** In copy, in docs, and in the interface. No inflation, no hedging,
+   no claims that are not verifiable in the source.
+
+## Accessibility & Inclusion
+
+**WCAG 2.1 AA is a hard requirement, not an aspiration.** Confirmed commitments:
+
+- Full keyboard navigation with visible focus management, and a skip-to-main-content link.
+- Screen reader support with ARIA attributes and live announcements for dynamic actions
+  (`src/components/accessibility/`).
+- In-app accessibility settings the visitor controls: **high contrast**, **reduce motion**, and
+  **font size**. Reduce-motion is honored by real behavior — the completion confetti checks it before
+  firing.
+- **Pinch-to-zoom is deliberately preserved.** `maximumScale` and `userScalable` are intentionally
+  left unset (WCAG 2.2 SC 1.4.4, Resize Text); the iOS input-zoom side effect is handled by setting
+  `font-size: 16px` on inputs instead of by disabling zoom. Do not "fix" this by locking the
+  viewport.
+- Touch targets and drag-and-drop activation are tuned per device class, including iOS Safari.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -37,7 +37,10 @@
   --gray-100: #EDEDEA;
   --gray-200: #E1E1DE;
   --gray-300: #CFCFCC;
-  --gray-500: #6F6F75;
+  /* Darkened from #6F6F75: as muted/label text it failed WCAG AA (4.5:1) on
+     every tinted surface — 4.26 on --gray-100, the kanban column and sidebar
+     background. #646469 clears 4.5:1 on ivory, gray-100, and paper alike. */
+  --gray-500: #646469;
   --gray-700: #3A3B41;
 
   /* ---------- Typography (platform fonts only — Inkwell rule #5) ---------- */

--- a/src/app/install/page.tsx
+++ b/src/app/install/page.tsx
@@ -48,7 +48,7 @@ export default function InstallPage() {
 
             <div className="space-y-4">
               <div>
-                <h3 className="mb-2 font-semibold">Chrome, Edge, or Brave</h3>
+                <h3 className="mb-2 text-lg font-semibold">Chrome, Edge, or Brave</h3>
                 <ol className="ml-5 space-y-2 text-muted-foreground list-decimal">
                   <li>Open Cascade in Chrome, Edge, or Brave browser</li>
                   <li>Look for the <strong>install icon</strong> in the address bar (looks like a computer monitor with a download arrow)</li>
@@ -63,12 +63,12 @@ export default function InstallPage() {
                 </ol>
               </div>
 
-              <div className="rounded-md bg-muted p-3 text-sm">
+              <div className="rounded-md bg-surface border border-border p-3 text-sm">
                 <strong>Quick tip:</strong> Press <kbd className="rounded border bg-background px-2 py-0.5 font-mono text-xs">Ctrl+Shift+A</kbd> (Windows/Linux) or <kbd className="rounded border bg-background px-2 py-0.5 font-mono text-xs">Cmd+Shift+A</kbd> (macOS) to open the install dialog
               </div>
 
               <div>
-                <h3 className="mb-2 font-semibold">Firefox</h3>
+                <h3 className="mb-2 text-lg font-semibold">Firefox</h3>
                 <p className="text-sm text-muted-foreground">
                   Firefox doesn&apos;t support automatic PWA installation. For the best experience, use Chrome or Edge.
                 </p>
@@ -85,7 +85,7 @@ export default function InstallPage() {
 
             <div className="space-y-4">
               <div>
-                <h3 className="mb-2 font-semibold">Safari (Required)</h3>
+                <h3 className="mb-2 text-lg font-semibold">Safari (Required)</h3>
                 <ol className="ml-5 space-y-2 text-muted-foreground list-decimal">
                   <li>Open Cascade in <strong>Safari</strong> browser (must be Safari, not Chrome)</li>
                   <li>Tap the <strong>Share button</strong> (square with arrow pointing up) at the bottom of the screen</li>
@@ -96,7 +96,7 @@ export default function InstallPage() {
                 </ol>
               </div>
 
-              <div className="rounded-md bg-muted p-3 text-sm">
+              <div className="rounded-md bg-surface border border-border p-3 text-sm">
                 <strong>Note:</strong> iOS requires Safari for PWA installation. Once installed, the app opens in its own window without browser UI.
               </div>
             </div>
@@ -111,7 +111,7 @@ export default function InstallPage() {
 
             <div className="space-y-4">
               <div>
-                <h3 className="mb-2 font-semibold">Chrome (Recommended)</h3>
+                <h3 className="mb-2 text-lg font-semibold">Chrome (Recommended)</h3>
                 <div className="space-y-3">
                   <div>
                     <p className="mb-2 text-sm font-medium">Method 1: Install Banner</p>
@@ -137,7 +137,7 @@ export default function InstallPage() {
                 </div>
               </div>
 
-              <div className="rounded-md bg-muted p-3 text-sm">
+              <div className="rounded-md bg-surface border border-border p-3 text-sm">
                 <strong>Tip:</strong> The installed app appears in your app drawer just like any other app and can be uninstalled from Settings.
               </div>
             </div>
@@ -148,25 +148,25 @@ export default function InstallPage() {
             <h2 className="text-2xl font-semibold">Why Install?</h2>
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-1">
-                <h3 className="font-semibold">Quick Access</h3>
+                <h3 className="text-lg font-semibold">Quick Access</h3>
                 <p className="text-sm text-muted-foreground">
                   Launch from your home screen, dock, or start menu
                 </p>
               </div>
               <div className="space-y-1">
-                <h3 className="font-semibold">Offline Support</h3>
+                <h3 className="text-lg font-semibold">Offline Support</h3>
                 <p className="text-sm text-muted-foreground">
                   Access your tasks without an internet connection
                 </p>
               </div>
               <div className="space-y-1">
-                <h3 className="font-semibold">Native Experience</h3>
+                <h3 className="text-lg font-semibold">Native Experience</h3>
                 <p className="text-sm text-muted-foreground">
                   Runs in its own window without browser UI
                 </p>
               </div>
               <div className="space-y-1">
-                <h3 className="font-semibold">Better Performance</h3>
+                <h3 className="text-lg font-semibold">Better Performance</h3>
                 <p className="text-sm text-muted-foreground">
                   Optimized startup and faster load times
                 </p>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { Button } from '@/components/ui/button';
-import { ChevronLeft, Shield, Database, Eye, Lock, FileText, User } from '@/lib/icons';
+import { ChevronLeft, Shield, Database, Eye, Lock, FileText, User, Check } from '@/lib/icons';
 import Link from 'next/link';
 
 export const metadata: Metadata = {
@@ -26,7 +26,7 @@ export default function PrivacyPolicyPage() {
           </Link>
           
           <div className="flex items-center gap-3 mb-4">
-            <Shield className="h-8 w-8 text-green-600" />
+            <Shield className="h-8 w-8 text-success" />
             <h1 className="text-3xl font-semibold">Privacy Policy</h1>
           </div>
           
@@ -34,16 +34,13 @@ export default function PrivacyPolicyPage() {
             Your privacy is our top priority. This policy explains how your data is handled in our Kanban task management application.
           </p>
           
-          <div className="flex gap-2 mt-4">
-            <Badge variant="secondary" className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
-              100% Local Storage
-            </Badge>
-            <Badge variant="secondary" className="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
-              No Data Collection
-            </Badge>
-            <Badge variant="secondary" className="bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">
-              Open Source
-            </Badge>
+          {/* Neutral by design: these are labels, not semantic states, and
+              three off-system hues (green/blue/purple) were the only place in
+              the app introducing a second, third, and fourth brand color. */}
+          <div className="flex flex-wrap gap-2 mt-4">
+            <Badge variant="secondary">100% Local Storage</Badge>
+            <Badge variant="secondary">No Data Collection</Badge>
+            <Badge variant="secondary">Open Source</Badge>
           </div>
         </div>
 
@@ -58,38 +55,66 @@ export default function PrivacyPolicyPage() {
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="grid md:grid-cols-2 gap-4">
-                <div className="bg-green-50 dark:bg-green-950/20 p-4 rounded-lg border border-green-200 dark:border-green-800">
-                  <h4 className="font-semibold text-green-800 dark:text-green-200 mb-2">
-                    ✓ Your data never leaves your device
+                <div
+                  className="p-4 rounded-lg"
+                  style={{
+                    background: "var(--ok-50)",
+                    border: "1.5px solid var(--ok-200)",
+                  }}
+                >
+                  <h4 className="text-base font-semibold mb-2 flex items-start gap-2">
+                    <Check className="size-4 shrink-0 mt-1 text-success" aria-hidden="true" />
+                    Your data never leaves your device
                   </h4>
-                  <p className="text-sm text-green-700 dark:text-green-300">
+                  <p className="text-sm" style={{ color: "var(--ink-2)" }}>
                     All tasks, boards, and settings are stored locally in your browser using IndexedDB.
                   </p>
                 </div>
                 
-                <div className="bg-green-50 dark:bg-green-950/20 p-4 rounded-lg border border-green-200 dark:border-green-800">
-                  <h4 className="font-semibold text-green-800 dark:text-green-200 mb-2">
-                    ✓ No servers store your personal information
+                <div
+                  className="p-4 rounded-lg"
+                  style={{
+                    background: "var(--ok-50)",
+                    border: "1.5px solid var(--ok-200)",
+                  }}
+                >
+                  <h4 className="text-base font-semibold mb-2 flex items-start gap-2">
+                    <Check className="size-4 shrink-0 mt-1 text-success" aria-hidden="true" />
+                    No servers store your personal information
                   </h4>
-                  <p className="text-sm text-green-700 dark:text-green-300">
+                  <p className="text-sm" style={{ color: "var(--ink-2)" }}>
                     We don&apos;t operate any databases or servers that collect your task data.
                   </p>
                 </div>
                 
-                <div className="bg-green-50 dark:bg-green-950/20 p-4 rounded-lg border border-green-200 dark:border-green-800">
-                  <h4 className="font-semibold text-green-800 dark:text-green-200 mb-2">
-                    ✓ You have complete control over your data
+                <div
+                  className="p-4 rounded-lg"
+                  style={{
+                    background: "var(--ok-50)",
+                    border: "1.5px solid var(--ok-200)",
+                  }}
+                >
+                  <h4 className="text-base font-semibold mb-2 flex items-start gap-2">
+                    <Check className="size-4 shrink-0 mt-1 text-success" aria-hidden="true" />
+                    You have complete control over your data
                   </h4>
-                  <p className="text-sm text-green-700 dark:text-green-300">
+                  <p className="text-sm" style={{ color: "var(--ink-2)" }}>
                     Export, import, or delete your data anytime using the built-in tools.
                   </p>
                 </div>
                 
-                <div className="bg-green-50 dark:bg-green-950/20 p-4 rounded-lg border border-green-200 dark:border-green-800">
-                  <h4 className="font-semibold text-green-800 dark:text-green-200 mb-2">
-                    ✓ We can&apos;t see what tasks you create
+                <div
+                  className="p-4 rounded-lg"
+                  style={{
+                    background: "var(--ok-50)",
+                    border: "1.5px solid var(--ok-200)",
+                  }}
+                >
+                  <h4 className="text-base font-semibold mb-2 flex items-start gap-2">
+                    <Check className="size-4 shrink-0 mt-1 text-success" aria-hidden="true" />
+                    We can&apos;t see what tasks you create
                   </h4>
-                  <p className="text-sm text-green-700 dark:text-green-300">
+                  <p className="text-sm" style={{ color: "var(--ink-2)" }}>
                     Your tasks are completely private and accessible only to you.
                   </p>
                 </div>
@@ -108,20 +133,26 @@ export default function PrivacyPolicyPage() {
             <CardContent className="space-y-4">
               <div className="space-y-3">
                 <div>
-                  <h4 className="font-semibold mb-2">Local Browser Storage</h4>
+                  <h4 className="text-base font-semibold mb-2">Local Browser Storage</h4>
                   <p className="text-muted-foreground text-sm mb-2">
                     All application data is stored locally in your browser using IndexedDB, a client-side database. This includes:
                   </p>
-                  <ul className="text-sm text-muted-foreground space-y-1 ml-4">
-                    <li>• Task titles, descriptions, and metadata</li>
-                    <li>• Board names, colors, and configurations</li>
-                    <li>• Application settings and preferences</li>
-                    <li>• Archived tasks and their history</li>
+                  <ul className="text-sm text-muted-foreground space-y-1 list-disc pl-5">
+                    <li>Task titles, descriptions, and metadata</li>
+                    <li>Board names, colors, and configurations</li>
+                    <li>Application settings and preferences</li>
+                    <li>Archived tasks and their history</li>
                   </ul>
                 </div>
                 
-                <div className="bg-blue-50 dark:bg-blue-950/20 p-4 rounded-lg border border-blue-200 dark:border-blue-800">
-                  <p className="text-sm text-blue-800 dark:text-blue-200">
+                <div
+                  className="p-4 rounded-lg"
+                  style={{
+                    background: "var(--info-50)",
+                    border: "1.5px solid var(--info-200)",
+                  }}
+                >
+                  <p className="text-sm" style={{ color: "var(--ink-2)" }}>
                     <strong>Technical Note:</strong> IndexedDB is a web standard that stores data directly on your device. 
                     This data persists between browser sessions but remains completely local to your machine.
                   </p>
@@ -140,28 +171,28 @@ export default function PrivacyPolicyPage() {
             </CardHeader>
             <CardContent className="space-y-4">
               <div>
-                <h4 className="font-semibold mb-2">Task Sharing</h4>
+                <h4 className="text-base font-semibold mb-2">Task Sharing</h4>
                 <p className="text-muted-foreground text-sm mb-3">
                   When you use the task sharing feature:
                 </p>
-                <ul className="text-sm text-muted-foreground space-y-1 ml-4">
-                  <li>• Email sharing opens your local email client with pre-filled content</li>
-                  <li>• Copy-to-clipboard creates formatted text locally in your browser</li>
-                  <li>• No data is transmitted to external servers during sharing</li>
-                  <li>• You choose exactly what information to share and with whom</li>
+                <ul className="text-sm text-muted-foreground space-y-1 list-disc pl-5">
+                  <li>Email sharing opens your local email client with pre-filled content</li>
+                  <li>Copy-to-clipboard creates formatted text locally in your browser</li>
+                  <li>No data is transmitted to external servers during sharing</li>
+                  <li>You choose exactly what information to share and with whom</li>
                 </ul>
               </div>
               
               <div>
-                <h4 className="font-semibold mb-2">Import/Export</h4>
+                <h4 className="text-base font-semibold mb-2">Import/Export</h4>
                 <p className="text-muted-foreground text-sm mb-3">
                   Data export and import features:
                 </p>
-                <ul className="text-sm text-muted-foreground space-y-1 ml-4">
-                  <li>• Generate JSON files containing your data locally</li>
-                  <li>• Files are created and downloaded directly from your browser</li>
-                  <li>• No cloud storage or external services involved</li>
-                  <li>• You maintain complete control over exported files</li>
+                <ul className="text-sm text-muted-foreground space-y-1 list-disc pl-5">
+                  <li>Generate JSON files containing your data locally</li>
+                  <li>Files are created and downloaded directly from your browser</li>
+                  <li>No cloud storage or external services involved</li>
+                  <li>You maintain complete control over exported files</li>
                 </ul>
               </div>
             </CardContent>
@@ -178,22 +209,22 @@ export default function PrivacyPolicyPage() {
             <CardContent>
               <div className="grid md:grid-cols-2 gap-4">
                 <div>
-                  <h4 className="font-semibold mb-2">Personal Information</h4>
-                  <ul className="text-sm text-muted-foreground space-y-1">
-                    <li>• No names or email addresses</li>
-                    <li>• No contact information</li>
-                    <li>• No location data</li>
-                    <li>• No demographic information</li>
+                  <h4 className="text-base font-semibold mb-2">Personal Information</h4>
+                  <ul className="text-sm text-muted-foreground space-y-1 list-disc pl-5">
+                    <li>No names or email addresses</li>
+                    <li>No contact information</li>
+                    <li>No location data</li>
+                    <li>No demographic information</li>
                   </ul>
                 </div>
                 
                 <div>
-                  <h4 className="font-semibold mb-2">Usage Analytics</h4>
-                  <ul className="text-sm text-muted-foreground space-y-1">
-                    <li>• No tracking cookies</li>
-                    <li>• No usage analytics</li>
-                    <li>• No behavioral data</li>
-                    <li>• No performance metrics</li>
+                  <h4 className="text-base font-semibold mb-2">Usage Analytics</h4>
+                  <ul className="text-sm text-muted-foreground space-y-1 list-disc pl-5">
+                    <li>No tracking cookies</li>
+                    <li>No usage analytics</li>
+                    <li>No behavioral data</li>
+                    <li>No performance metrics</li>
                   </ul>
                 </div>
               </div>
@@ -210,20 +241,20 @@ export default function PrivacyPolicyPage() {
             </CardHeader>
             <CardContent className="space-y-4">
               <div>
-                <h4 className="font-semibold mb-2">Static Site Architecture</h4>
+                <h4 className="text-base font-semibold mb-2">Static Site Architecture</h4>
                 <p className="text-muted-foreground text-sm mb-3">
                   This application is built as a static site with no backend servers:
                 </p>
-                <ul className="text-sm text-muted-foreground space-y-1 ml-4">
-                  <li>• Hosted on AWS S3 and CloudFront (static file hosting)</li>
-                  <li>• No server-side processing or databases</li>
-                  <li>• All functionality runs in your browser</li>
-                  <li>• Open source code available for inspection</li>
+                <ul className="text-sm text-muted-foreground space-y-1 list-disc pl-5">
+                  <li>Hosted on AWS S3 and CloudFront (static file hosting)</li>
+                  <li>No server-side processing or databases</li>
+                  <li>All functionality runs in your browser</li>
+                  <li>Open source code available for inspection</li>
                 </ul>
               </div>
               
               <div>
-                <h4 className="font-semibold mb-2">Browser Compatibility</h4>
+                <h4 className="text-base font-semibold mb-2">Browser Compatibility</h4>
                 <p className="text-muted-foreground text-sm">
                   The app requires modern browser features (IndexedDB, ES6+) but doesn&apos;t use any tracking or analytics libraries.
                 </p>

--- a/src/components/InstallPWA.tsx
+++ b/src/components/InstallPWA.tsx
@@ -126,13 +126,16 @@ export default function InstallPWA() {
     return null;
   }
 
+  // Anchored to the bottom: at top-3 with z-50 this sat on top of the sticky
+  // /about nav and the board header, hiding the page title and primary
+  // controls on every first visit.
   return (
     <div
       role="dialog"
       aria-labelledby="install-pwa-title"
       aria-describedby="install-pwa-description"
-      className="fixed inset-x-3 top-3 z-50 rounded-lg border bg-background/95 p-4 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/80"
-      style={{ paddingTop: "calc(env(safe-area-inset-top) + 0.75rem)" }}
+      className="fixed inset-x-3 bottom-3 z-50 rounded-lg border bg-background/95 p-4 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/80 sm:left-auto sm:right-3 sm:max-w-sm"
+      style={{ paddingBottom: "calc(env(safe-area-inset-bottom) + 0.75rem)" }}
     >
       <div className="flex items-start gap-3">
         <div className="flex-shrink-0">

--- a/src/components/about/FeatureCard.tsx
+++ b/src/components/about/FeatureCard.tsx
@@ -12,7 +12,9 @@ export function FeatureCard({ icon: Icon, title, description }: FeatureCardProps
       className="transition-shadow duration-200"
       style={{
         background: "var(--paper-card)",
-        border: "1px solid var(--hairline)",
+        // 1.5px --hairline-strong is the system's card rule; this was 1px
+        // --hairline, a lighter divider token used for a bounded surface.
+        border: "1.5px solid var(--hairline-strong)",
         borderRadius: "12px",
         boxShadow: "var(--shadow-xs)",
         padding: "20px 18px 18px",

--- a/src/components/about/HeroSection.tsx
+++ b/src/components/about/HeroSection.tsx
@@ -7,7 +7,7 @@ export function HeroSection() {
   return (
     <section className="py-24 lg:py-32">
       <div className="mx-auto max-w-4xl px-6 text-center">
-        <p className="text-xs uppercase tracking-widest text-muted-foreground mb-6">
+        <p className="label-eyebrow mb-6">
           Privacy-First Task Management
         </p>
 

--- a/src/components/about/HowItWorksSection.tsx
+++ b/src/components/about/HowItWorksSection.tsx
@@ -1,6 +1,8 @@
+import { Check } from "@/lib/icons";
+
 function MockTaskCard({ children }: { children: React.ReactNode }) {
   return (
-    <div className="rounded-lg border border-border bg-white p-3 shadow-sm dark:bg-surface">
+    <div className="rounded-lg border border-border bg-card p-3 shadow-sm">
       {children}
     </div>
   );
@@ -18,10 +20,8 @@ function MockColumn({
   return (
     <div className="flex-1 min-w-[140px] rounded-xl bg-muted/30 p-3">
       <div className="mb-3 flex items-center gap-2">
-        <span className={`size-2 rounded-full ${dotClass}`} />
-        <span className="text-xs font-semibold text-muted-foreground">
-          {title}
-        </span>
+        <span className={`status-dot ${dotClass}`} aria-hidden="true" />
+        <span className="label-eyebrow">{title}</span>
       </div>
       <div className="space-y-2">{children}</div>
     </div>
@@ -36,7 +36,10 @@ function MockProgressBar({ percent }: { percent: string }) {
         <span>{percent}</span>
       </div>
       <div className="h-1.5 w-full rounded-full bg-surface-2">
-        <div className={`h-1.5 w-[60%] rounded-full bg-primary`} />
+        <div
+          className="h-1.5 rounded-full bg-primary"
+          style={{ width: percent }}
+        />
       </div>
     </div>
   );
@@ -45,7 +48,7 @@ function MockProgressBar({ percent }: { percent: string }) {
 function KanbanMock() {
   return (
     <div className="flex gap-3 overflow-x-auto rounded-xl border border-border bg-surface p-4 shadow-sm">
-      <MockColumn title="To Do" dotClass="bg-muted-2">
+      <MockColumn title="To Do" dotClass="status-dot--todo">
         <MockTaskCard>
           <p className="text-sm font-medium text-foreground">Plan Q3 report</p>
           <p className="mt-1 text-xs text-muted-foreground">Due: Mon</p>
@@ -55,17 +58,21 @@ function KanbanMock() {
         </MockTaskCard>
       </MockColumn>
 
-      <MockColumn title="In Progress" dotClass="bg-warning">
+      <MockColumn title="In Progress" dotClass="status-dot--in-progress">
         <MockTaskCard>
           <p className="text-sm font-medium text-foreground">Design hero section</p>
           <MockProgressBar percent="60%" />
         </MockTaskCard>
       </MockColumn>
 
-      <MockColumn title="Done" dotClass="bg-success">
+      <MockColumn title="Done" dotClass="status-dot--done">
         <MockTaskCard>
           <div className="flex items-center gap-1.5">
-            <span className="text-sm text-success">&#10003;</span>
+            <Check
+              className="size-4 shrink-0 text-success"
+              aria-hidden="true"
+              strokeWidth={2.5}
+            />
             <p className="text-sm font-medium text-foreground line-through opacity-70">
               Write copy
             </p>

--- a/src/components/kanban/KanbanColumn.tsx
+++ b/src/components/kanban/KanbanColumn.tsx
@@ -72,13 +72,10 @@ function KanbanColumn({ title, tasks, status, boards, currentBoardId, highlighte
             style={{ background: STATUS_DOT_COLOR[status] }}
             aria-hidden="true"
           />
-          <span
-            style={{
-              fontSize: "13px",
-              fontWeight: 600,
-              color: "var(--ink-1)",
-            }}
-          >
+          {/* Mono label voice, matching the count pill beside it — these two
+              sat in one row using two different type systems. Keeps ink-1
+              rather than the label default, as the column's primary name. */}
+          <span className="label-eyebrow" style={{ color: "var(--ink-1)" }}>
             {title}
           </span>
           <span className="kanban-column__count">{tasks.length}</span>


### PR DESCRIPTION
Ship-ready polish pass across all four surfaces (board, `/about`, `/install`, `/privacy`), driven by a design-system capture done in the same session.

## Accessibility — WCAG 2.1 AA is a hard product constraint

| Fix | Before | After |
|---|---|---|
| `--muted` / every mono label on tinted surfaces | 4.37 / **4.26** / 3.81 | **5.15 / 5.02 / 4.49** |
| `/install` "Quick tip" callouts (x3) | **3.09** | **15.65** |

The first was systemic. `--gray-500` is `--muted`, `--muted-foreground`, `--ink-3/4` *and* the color of every mono label — and it failed 4.5:1 on `--gray-100`, which is the kanban column and sidebar surface. Darkened to `#646469`, verified against all five real background pairings.

The second was a token misuse: `bg-muted` paints the muted *text* token as a background, producing a dark bar with graphite text on it.

## Design-system drift

- **`/privacy` rendered in raw Tailwind `green-*`, `blue-*`, and `purple-*`** — 18 lines of foreign palette on a system whose only success color is a muted olive. Rebuilt on `--ok-*` / `--info-*`; olive-tint is now the only saturated surface on the page. Three decorative multi-hue badges → neutral.
- **Three competing label systems on `/about`** (sans kicker / mono eyebrow / sans mock label) → one.
- **Kanban column headers** were `system-ui 13px` sitting beside their own `mono 11px` count pills — two type systems in one 40px row.
- **`/install` heading hierarchy was inverted**: every H3 at 36px under a 24px H2, tying the page title. Now 36 → 24 → 18.
- **`/privacy` sub-headings were ~2x their parent card title** (30px under 16px).
- Mock kanban on `/about` used `bg-white` and a gray To Do dot; now `--card` and Blueprint, matching the app it depicts.

## Defects

- **Install prompt covered the page header on every first visit** — `fixed top-3 z-50`, same z-index as the sticky nav. Moved to bottom, constrained to a card on desktop.
- **Progress bar ignored its own prop** — `percent` shown as text while width was hardcoded `w-[60%]`.
- 5 unicode `✓` glyphs standing in for icons → Lucide `Check`; 24 hand-typed `•` characters → real `list-disc` semantics.

## Also added

`PRODUCT.md`, `DESIGN.md`, and `.impeccable/design.json` — the durable product record and the documented Inkwell design system (tokens, tonal ramps, named rules) that these fixes enforce.

## Not included — reported, not fixed

1. **Duplicate default board.** "Work Tasks" renders twice in the sidebar (one with 1 task, one with 0). `validation.ts` treats duplicate default boards as invalid, so this is real state corruption, likely a double-init race. Needs its own debugging pass.
2. **6 more files use foreign Tailwind palette** (`ConfirmationDialog`, `MoveTaskDialog`, `ShareTaskDialog`, `CompleteStep`, 2 user-guide files) — same bug class as `/privacy`, outside the four-surface scope.
3. **`12.5px` hardcoded in 6 files**, off every documented scale. Self-consistent, so normalizing is out-of-scope cleanup.
4. **`CardTitle` renders as a `<div>`** — no heading semantics for screen readers. Shared component, app-wide blast radius.

## Test plan

- [x] `bun run test` — 53 files, **693 tests passing**
- [x] `bun run lint` — 0 errors (42 pre-existing warnings unchanged)
- [x] `tsc --noEmit` — no type errors in any changed file
- [x] Impeccable design detector — advisory-only, all on pre-existing literals
- [x] Rendered verification of all four surfaces at desktop width, computed contrast measured in-browser rather than estimated

Note: unrelated pre-existing working-tree edits (`bun.lock`, `package.json`, `coding-standards.md`, `.agents/`, `skills-lock.json`) were deliberately left out of this branch.

https://claude.ai/code/session_01WU1eJivJoziLBs4qs8F71j

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/kanban-todos/pull/104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->